### PR TITLE
FileSyncer: import typed_data

### DIFF
--- a/lib/data/nextcloud/file_syncer.dart
+++ b/lib/data/nextcloud/file_syncer.dart
@@ -1,6 +1,7 @@
 
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:encrypt/encrypt.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
Build on iOS failed since for some reason `Uint8List` wasn't being provided by `flutter/foundation.dart`.