### PR TITLE
english translation: improvements for consistency

### DIFF
--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 2
 /// Strings: 119 (59 per locale)
 ///
-/// Built on 2022-10-16 at 21:46 UTC
+/// Built on 2022-10-17 at 00:15 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -261,7 +261,7 @@ class _StringsHomeTitlesEn {
 
 	// Translations
 	String get home => 'Recent notes';
-	String get browse => 'Browse';
+	String get browse => 'All notes';
 	String get whiteboard => 'Whiteboard';
 	String get settings => 'Settings';
 }
@@ -313,7 +313,7 @@ class _StringsSettingsAccentColorPickerEn {
 
 	// Translations
 	String get pickAColor => 'Pick a color';
-	String get gotIt => 'Got it';
+	String get gotIt => 'Confirm';
 }
 
 // Path: login.feedbacks
@@ -624,7 +624,7 @@ extension on _StringsEn {
 			case 'home.tabs.whiteboard': return 'Whiteboard';
 			case 'home.tabs.settings': return 'Settings';
 			case 'home.titles.home': return 'Recent notes';
-			case 'home.titles.browse': return 'Browse';
+			case 'home.titles.browse': return 'All notes';
 			case 'home.titles.whiteboard': return 'Whiteboard';
 			case 'home.titles.settings': return 'Settings';
 			case 'home.tooltips.showHideActions': return 'Show/hide actions';
@@ -644,7 +644,7 @@ extension on _StringsEn {
 			case 'settings.themeModes.light': return 'Light';
 			case 'settings.themeModes.dark': return 'Dark';
 			case 'settings.accentColorPicker.pickAColor': return 'Pick a color';
-			case 'settings.accentColorPicker.gotIt': return 'Got it';
+			case 'settings.accentColorPicker.gotIt': return 'Confirm';
 			case 'login.title': return 'Login';
 			case 'login.feedbacks.checkUsername': return 'Please double check your username or email.';
 			case 'login.feedbacks.enterNcPassword': return 'Please enter your Nextcloud password.';

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -8,13 +8,13 @@
 		},
 		"titles": {
 			"home": "Recent notes",
-			"browse": "Browse",
+			"browse": "All Notes",
 			"whiteboard": "Whiteboard",
 			"settings": "Settings"
 		},
 		"tooltips": {
-			"showHideActions": "Show/hide actions",
-			"newNote": "New note",
+			"showHideActions": "show/hide actions",
+			"newNote": "New Note",
 			"showUpdateDialog": "Show update dialog"
 		},
 		"backFolder": "(Back)",
@@ -38,7 +38,7 @@
 		},
 		"accentColorPicker": {
 			"pickAColor": "Pick a color",
-			"gotIt": "Got it"
+			"gotIt": "Confirm"
 		}
 	},
 	"login": {
@@ -53,7 +53,7 @@
 		},
 		"form": {
 			"useCustomServer": "I want to use a custom Nextcloud server",
-            "customServerUrl": "Custom server URL",
+			"customServerUrl": "Custom server URL",
 			"username": "Username or email",
 			"ncPassword": "Nextcloud password",
 			"encPassword": "Encryption password",
@@ -84,13 +84,13 @@
 	"editor": {
 		"toolbar": {
 			"fountainPen": "Fountain pen",
-			"toggleColors": "Toggle colors (Ctrl C)",
-			"toggleEraser": "Toggle eraser (Ctrl E)",
+			"toggleColors": "Toggle colors (Ctrl + C)",
+			"toggleEraser": "Toggle eraser (Ctrl + E)",
 			"photo": "Photo",
-			"toggleFingerDrawing": "Toggle finger drawing (Ctrl F)",
+			"toggleFingerDrawing": "Toggle finger drawing (Ctrl + F)",
 			"undo": "Undo",
 			"redo": "Redo",
-			"export": "Export (Ctrl Shift S)",
+			"export": "Export (Ctrl + Shift + S)",
 			"exportAs": "Export as:"
 		}
 	}

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -7,14 +7,14 @@
 			"settings": "Settings"
 		},
 		"titles": {
-			"home": "Recent Notes",
-			"browse": "All Notes",
+			"home": "Recent notes",
+			"browse": "All notes",
 			"whiteboard": "Whiteboard",
 			"settings": "Settings"
 		},
 		"tooltips": {
-			"showHideActions": "show/hide actions",
-			"newNote": "New Note",
+			"showHideActions": "Show/hide actions",
+			"newNote": "New note",
 			"showUpdateDialog": "Show update dialog"
 		},
 		"backFolder": "(Back)",
@@ -83,9 +83,9 @@
 	},
 	"editor": {
 		"toolbar": {
-			"fountainPen": "Fountain Pen",
-			"toggleColors": "Toggle Colors (Ctrl + C)",
-			"toggleEraser": "Toggle Eraser (Ctrl + E)",
+			"fountainPen": "Fountain pen",
+			"toggleColors": "Toggle colors (Ctrl C)",
+			"toggleEraser": "Toggle eraser (Ctrl E)",
 			"photo": "Photo",
 			"toggleFingerDrawing": "Toggle finger drawing (Ctrl + F)",
 			"undo": "Undo",

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -7,7 +7,7 @@
 			"settings": "Settings"
 		},
 		"titles": {
-			"home": "Recent notes",
+			"home": "Recent Notes",
 			"browse": "All Notes",
 			"whiteboard": "Whiteboard",
 			"settings": "Settings"
@@ -83,9 +83,9 @@
 	},
 	"editor": {
 		"toolbar": {
-			"fountainPen": "Fountain pen",
-			"toggleColors": "Toggle colors (Ctrl + C)",
-			"toggleEraser": "Toggle eraser (Ctrl + E)",
+			"fountainPen": "Fountain Pen",
+			"toggleColors": "Toggle Colors (Ctrl + C)",
+			"toggleEraser": "Toggle Eraser (Ctrl + E)",
 			"photo": "Photo",
 			"toggleFingerDrawing": "Toggle finger drawing (Ctrl + F)",
 			"undo": "Undo",

--- a/lib/i18n/strings.i18n.json
+++ b/lib/i18n/strings.i18n.json
@@ -87,10 +87,10 @@
 			"toggleColors": "Toggle colors (Ctrl C)",
 			"toggleEraser": "Toggle eraser (Ctrl E)",
 			"photo": "Photo",
-			"toggleFingerDrawing": "Toggle finger drawing (Ctrl + F)",
+			"toggleFingerDrawing": "Toggle finger drawing (Ctrl F)",
 			"undo": "Undo",
 			"redo": "Redo",
-			"export": "Export (Ctrl + Shift + S)",
+			"export": "Export (Ctrl Shift S)",
 			"exportAs": "Export as:"
 		}
 	}


### PR DESCRIPTION
I changed some of the english translations to be more in line with what they mean/what they do.
Most of it are just proposals, if you don't like them it's also fine with me.

- capital letters
- Ctrl + Key instead of Ctrl Key
- "All notes" as the title of for the browse section, similar to how "Recent notes" already is