### PR TITLE
editor: do not remove stylus strokes on zoom gesture

### DIFF
--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -227,8 +227,8 @@ class _EditorState extends State<Editor> {
     if (lastSeenPointerCount >= 2) { // was a zoom gesture, ignore
       lastSeenPointerCount = lastSeenPointerCount;
       return false;
-    } else if (details.pointerCount >= 2 && Prefs.editorFingerDrawing.value) { // is a zoom gesture, remove accidental stroke
-      if (lastSeenPointerCount == 1) {
+    } else if (details.pointerCount >= 2) { // is a zoom gesture, remove accidental stroke
+      if (lastSeenPointerCount == 1 && Prefs.editorFingerDrawing.value) {
         setState(() {
           EditorHistoryItem? item = history.removeAccidentalStroke();
           if (item != null) {

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -227,7 +227,7 @@ class _EditorState extends State<Editor> {
     if (lastSeenPointerCount >= 2) { // was a zoom gesture, ignore
       lastSeenPointerCount = lastSeenPointerCount;
       return false;
-    } else if (details.pointerCount >= 2) { // is a zoom gesture, remove accidental stroke
+    } else if (details.pointerCount >= 2 && Prefs.editorFingerDrawing.value) { // is a zoom gesture, remove accidental stroke
       if (lastSeenPointerCount == 1) {
         setState(() {
           EditorHistoryItem? item = history.removeAccidentalStroke();


### PR DESCRIPTION
This seems to fix the issue I'm having here: #64 

Thanks for reviewing.