### PR TITLE
updates: fix deprecated function error and fix infinite loading after error on login for nc

### DIFF
--- a/lib/components/nextcloud/login_group.dart
+++ b/lib/components/nextcloud/login_group.dart
@@ -81,7 +81,9 @@ class _LoginInputGroupState extends State<LoginInputGroup> {
     }
 
     try {
-      _isLoading = true;
+      setState(() {
+        _isLoading = true;
+      });
       await widget.tryLogin(LoginDetailsStruct(
         url: _usingCustomServer ? _customServerController.text : null,
         loginName: _usernameController.text,
@@ -101,7 +103,9 @@ class _LoginInputGroupState extends State<LoginInputGroup> {
         _errorMessage = t.login.feedbacks.encLoginFailed;
       });
     } finally {
-      _isLoading = false;
+      setState(() {
+        _isLoading = false;
+      });
     }
   }
 

--- a/lib/data/file_manager/file_manager_nonweb.dart
+++ b/lib/data/file_manager/file_manager_nonweb.dart
@@ -13,7 +13,7 @@ Future fmExportFile(String fileName, List<int> bytes) async {
 
   if (Platform.isAndroid || Platform.isIOS) { // mobile, open share dialog
     await fileWriteFuture;
-    await Share.shareFilesWithResult([file.path]);
+    await Share.shareXFiles([XFile(file.path)]);
   } else { // desktop, open save-as dialog
     String? outputFile = await FilePicker.platform.saveFile(
       fileName: fileName,


### PR DESCRIPTION
This function is deprecated as stated in their implementation of [shareFiles](https://github.com/fluttercommunity/plus_plugins/blob/21f38017fefcb2ceddac275cd4d76e26aaaab9a2/packages/share_plus/share_plus/lib/share_plus.dart#L72).

Could have technical reasons or even security because they want to work with XFile, not File anymore.


Edit: The second commit is about an error I have discovered when an error occured, that the spinning of the login button wouldn't stop, setState was missing.