### PR TITLE
Add extra 0 to version codes

### DIFF
--- a/lib/components/settings/update_manager.dart
+++ b/lib/components/settings/update_manager.dart
@@ -67,7 +67,7 @@ abstract class UpdateManager {
 
     if (newestVersion <= currentVersion) {
       return UpdateStatus.upToDate;
-    } else if (newestVersion == currentVersion + 1 && !kDebugMode) {
+    } else if (newestVersion <= currentVersion + 10 && !kDebugMode) {
       // ignore 1 minor update so the user isn't prompted too often (debug mode ignores this)
       return UpdateStatus.updateOptional;
     } else {

--- a/lib/data/version.dart
+++ b/lib/data/version.dart
@@ -1,2 +1,2 @@
 /// The current app version as an ordinal number.
-const int buildNumber = 502;
+const int buildNumber = 5020;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.5.2+502
+version: 0.5.2+5020
 
 environment:
   sdk: ">=2.17.6 <3.0.0"


### PR DESCRIPTION
This lets me replace 5020 with 5021 for Google Play users due to the last-minute bug fix for #190.

This won't go into effect until v0.5.3