### PR TITLE
invert: invert image data directly instead of snapshot

### DIFF
--- a/lib/components/canvas/_svg_editor_image.dart
+++ b/lib/components/canvas/_svg_editor_image.dart
@@ -5,7 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:saber/components/canvas/_editor_image.dart';
-import 'package:saber/components/canvas/invert_shader.dart';
 import 'package:saber/components/canvas/shader_sampler.dart';
 
 class SvgEditorImage extends EditorImage {
@@ -15,8 +14,6 @@ class SvgEditorImage extends EditorImage {
   Uint8List get bytes => Uint8List.fromList(utf8.encode(svgString));
   @override
   set bytes(Uint8List bytes) {}
-
-  late final ui.FragmentShader _shader = InvertShader.create();
 
   SvgEditorImage({
     required super.id,
@@ -165,10 +162,10 @@ class SvgEditorImage extends EditorImage {
         await precache(context);
       },
       shaderBuilder: (ui.Image image, Size size) {
-        _shader.setFloat(0, size.width);
-        _shader.setFloat(1, size.height);
-        _shader.setImageSampler(0, image);
-        return _shader;
+        invertShader.setFloat(0, size.width);
+        invertShader.setFloat(1, size.height);
+        invertShader.setImageSampler(0, image);
+        return invertShader;
       },
       child: SvgPicture.string(
         svgString,

--- a/lib/components/canvas/_svg_editor_image.dart
+++ b/lib/components/canvas/_svg_editor_image.dart
@@ -37,6 +37,7 @@ class SvgEditorImage extends EditorImage {
   }) :  super(
           extension: '.svg',
           bytes: Uint8List(0),
+          onMainThread: true, // doesn't matter for SVGs
         );
 
   factory SvgEditorImage.fromJson(Map<String, dynamic> json, {

--- a/lib/components/canvas/canvas_image.dart
+++ b/lib/components/canvas/canvas_image.dart
@@ -182,21 +182,11 @@ class _CanvasImageState extends State<CanvasImage> {
                       size: widget.image.srcRect.size,
                       child: Transform.translate(
                         offset: -widget.image.srcRect.topLeft,
-                        child: ShaderSampler(
-                          shaderEnabled: imageBrightness == Brightness.dark,
-                          prepareForSnapshot: () async {
-                            await widget.image.precache(context);
-                          },
-                          shaderBuilder: (ui.Image image, Size size) {
-                            shader.setFloat(0, size.width);
-                            shader.setFloat(1, size.height);
-                            shader.setImageSampler(0, image);
-                            return shader;
-                          },
-                          child: widget.image.buildImageWidget(
-                            overrideBoxFit: widget.overrideBoxFit,
-                            isBackground: widget.isBackground,
-                          ),
+                        child: widget.image.buildImageWidget(
+                          overrideBoxFit: widget.overrideBoxFit,
+                          isBackground: widget.isBackground,
+                          imageBrightness: imageBrightness,
+                          context: context,
                         ),
                       ),
                     ),

--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -274,10 +274,13 @@ class EditorCoreInfo {
       }
     }
 
+    // now that we're back on the main thread,
+    // we can parse the images
     for (final page in coreInfo.pages) {
       for (final image in page.images) {
-        image.waitingForIsolateToFinish = false;
+        await image.getImage(pageSize: page.size);
       }
+      page.backgroundImage?.getImage(pageSize: page.size);
     }
 
     return coreInfo;

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -175,6 +175,7 @@ class EditorPage extends Listenable {
     json,
     assets: assets,
     isThumbnail: isThumbnail,
+    onMainThread: false,
   );
 
   final List<VoidCallback> _listeners = [];


### PR DESCRIPTION
- Closes #627 
- SVGs are still using a snapshot for inversion

