### PR TITLE
snap: explicitly set version

### DIFF
--- a/scripts/apply_version.sh
+++ b/scripts/apply_version.sh
@@ -97,7 +97,7 @@ echo " - Updating version in pubspec.yaml" # e.g. version: 5.5.0+5050
 sed -i "s/version: .*/version: $BUILD_NAME+$BUILD_NUMBER/g" pubspec.yaml
 
 echo " - Updating version in snap/snapcraft.yaml" # e.g. source-tag: v0.5.5
-sed -i "s/source-tag: v.*/source-tag: v$BUILD_NAME/g" snap/snapcraft.yaml
+sed -i "s/version: v.*/version: v$BUILD_NAME/g" snap/snapcraft.yaml
 
 echo " - Updating VERSION_AS_NUMBER in windows/runner/Runner.rc" # e.g. #define VERSION_AS_NUMBER 0,5,5,0
 BUILD_NAME_WITH_COMMAS=${BUILD_NAME//./,}

--- a/scripts/apply_version.sh
+++ b/scripts/apply_version.sh
@@ -96,8 +96,8 @@ sed -i "s/buildYear = .*/buildYear = $YEAR;/g" lib/data/version.dart
 echo " - Updating version in pubspec.yaml" # e.g. version: 5.5.0+5050
 sed -i "s/version: .*/version: $BUILD_NAME+$BUILD_NUMBER/g" pubspec.yaml
 
-echo " - Updating version in snap/snapcraft.yaml" # e.g. source-tag: v0.5.5
-sed -i "s/version: v.*/version: v$BUILD_NAME/g" snap/snapcraft.yaml
+echo " - Updating version in snap/snapcraft.yaml" # e.g. version: 0.5.5
+sed -i "s/version: .*/version: $BUILD_NAME/g" snap/snapcraft.yaml
 
 echo " - Updating VERSION_AS_NUMBER in windows/runner/Runner.rc" # e.g. #define VERSION_AS_NUMBER 0,5,5,0
 BUILD_NAME_WITH_COMMAS=${BUILD_NAME//./,}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: saber # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
 adopt-info: saber
+version: 0.13.1
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 license: GPL-3.0
@@ -35,7 +36,7 @@ parts:
     after: [rustup]
     source: https://github.com/adil192/saber.git
     source-type: git
-    source-tag: v0.13.1
+    source-tag: v$SNAPCRAFT_PROJECT_VERSION
     plugin: flutter
     #build-attributes: [enable-patchelf]
     build-packages:


### PR DESCRIPTION
In my repo, the version was adopted from the appstream metadata file which is also used by the flatpak. But, after shifting to this repo, I noticed that for the last two versions, it's still showing the version 0.12.10. So, I am changing this manually. The github workflow will also change according to this, which I will also do.