### PR TITLE
feat: add s-pen button erasing

### DIFF
--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -23,6 +23,7 @@ class CanvasGestureDetector extends StatefulWidget {
     required this.onDrawUpdate,
     required this.onDrawEnd,
     required this.onPressureChanged,
+    required this.onStylusButtonChanged,
 
     required this.undo,
     required this.redo,
@@ -45,6 +46,7 @@ class CanvasGestureDetector extends StatefulWidget {
   /// Called when the pressure of the stylus changes,
   /// pressure is negative if stylus button is pressed
   final ValueChanged<double?> onPressureChanged;
+  final ValueChanged<bool> onStylusButtonChanged;
 
   final VoidCallback undo;
   final VoidCallback redo;
@@ -204,6 +206,8 @@ class _CanvasGestureDetectorState extends State<CanvasGestureDetector> {
     double? pressure;
     if (event.kind == PointerDeviceKind.stylus) {
       pressure = event.pressure;
+      bool buttonPressed = event.buttons == kPrimaryStylusButton;
+      widget.onStylusButtonChanged(buttonPressed);
     } else if (event.kind == PointerDeviceKind.invertedStylus) {
       pressure = -event.pressure;
     } else if (Platform.isLinux && event.pressureMin != event.pressureMax) {
@@ -211,6 +215,12 @@ class _CanvasGestureDetectorState extends State<CanvasGestureDetector> {
       pressure = event.pressure;
     }
     widget.onPressureChanged(pressure);
+  }
+
+  void _listenerPointerUpEvent(PointerEvent event) {
+    if (event.kind == PointerDeviceKind.stylus) {
+      widget.onStylusButtonChanged(false);
+    }
   }
 
   @override
@@ -222,6 +232,7 @@ class _CanvasGestureDetectorState extends State<CanvasGestureDetector> {
         Listener(
           onPointerDown: _listenerPointerEvent,
           onPointerMove: _listenerPointerEvent,
+          onPointerUp: _listenerPointerUpEvent,
           child: GestureDetector(
             onSecondaryTapUp: (TapUpDetails details) => widget.undo(),
             onTertiaryTapUp: (TapUpDetails details) => widget.redo(),

--- a/lib/components/canvas/canvas_gesture_detector.dart
+++ b/lib/components/canvas/canvas_gesture_detector.dart
@@ -204,23 +204,26 @@ class _CanvasGestureDetectorState extends State<CanvasGestureDetector> {
 
   void _listenerPointerEvent(PointerEvent event) {
     double? pressure;
+    bool stylusButtonPressed = false;
+
     if (event.kind == PointerDeviceKind.stylus) {
       pressure = event.pressure;
-      bool buttonPressed = event.buttons == kPrimaryStylusButton;
-      widget.onStylusButtonChanged(buttonPressed);
+      stylusButtonPressed = event.buttons == kPrimaryStylusButton;
     } else if (event.kind == PointerDeviceKind.invertedStylus) {
-      pressure = -event.pressure;
+      pressure = event.pressure;
+      stylusButtonPressed = true; // treat eraser as stylus button
     } else if (Platform.isLinux && event.pressureMin != event.pressureMax) {
       // if min == max, then the device isn't pressure sensitive
       pressure = event.pressure;
     }
+
     widget.onPressureChanged(pressure);
+    widget.onStylusButtonChanged(stylusButtonPressed);
   }
 
   void _listenerPointerUpEvent(PointerEvent event) {
-    if (event.kind == PointerDeviceKind.stylus) {
-      widget.onStylusButtonChanged(false);
-    }
+    widget.onPressureChanged(null);
+    widget.onStylusButtonChanged(false);
   }
 
   @override

--- a/lib/components/toolbar/toolbar.dart
+++ b/lib/components/toolbar/toolbar.dart
@@ -131,11 +131,7 @@ class _ToolbarState extends State<Toolbar> {
 
   void toggleEraser() {
     toolOptionsType = ToolOptions.hide;
-    if (widget.currentTool is Eraser) {
-      widget.setTool(Pen.currentPen);
-    } else {
-      widget.setTool(Eraser());
-    }
+    widget.setTool(Eraser()); // this toggles eraser
   }
   void toggleColorOptions() {
     setState(() {


### PR DESCRIPTION
This adds the feature to switch to the eraser while the button on a stylus (tested with the Samsung S-Pen) is pressed and to switch back to the previous tool when the button is released, which is similar to the behavior in Samsung Notes.