### PR TITLE
fix: keep erasing after releasing stylus button

### DIFF
--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -131,6 +131,8 @@ class EditorState extends State<Editor> {
   Tool? tmpTool;
   /// If the stylus button is pressed.
   bool stylusButtonPressed = false;
+  // If the eraser is selected because the stylus button has been pressed
+  bool currentlyErasing = false;
 
   @override
   void initState() {
@@ -592,6 +594,12 @@ class EditorState extends State<Editor> {
         ));
       } else if (currentTool is Eraser) {
         final erased = (currentTool as Eraser).onDragEnd();
+        if (currentlyErasing){
+          currentlyErasing = false;
+          currentTool = tmpTool!;
+          tmpTool = null;
+          setState(() {});
+        }
         if (erased.isEmpty) return;
         history.recordChange(EditorHistoryItem(
           type: EditorHistoryItemType.erase,
@@ -653,11 +661,7 @@ class EditorState extends State<Editor> {
       }
       currentTool = Eraser();
       setState(() {});
-    } else {
-      if (tmpTool == null) return;
-      currentTool = tmpTool!;
-      tmpTool = null;
-      setState(() {});
+      currentlyErasing = true;
     }
   }
 


### PR DESCRIPTION
Previously, when erasing using the stylus button, the eraser got disabled after releasing the button. This commit makes the tool switch after lifting the stylus from the screen, so you don't need to press the button the whole time you want to erase something, similar to other handwritten note apps.