### PR TITLE
fix: massively reduce filesize

### DIFF
--- a/lib/data/extensions/point_extensions.dart
+++ b/lib/data/extensions/point_extensions.dart
@@ -13,9 +13,9 @@ extension PointExtensions on Point {
   );
 
   Map<String, dynamic> toJson() => {
-    'x': double.parse((x).toStringAsFixed(4)),
-    'y': double.parse((y).toStringAsFixed(4)),
-    'p': double.parse((p).toStringAsFixed(8)),
+    'x': double.parse(x.toStringAsFixed(4)),
+    'y': double.parse(y.toStringAsFixed(4)),
+    'p': double.parse(p.toStringAsFixed(8)),
   };
 
   Point operator +(Offset offset) => Point(

--- a/lib/data/extensions/point_extensions.dart
+++ b/lib/data/extensions/point_extensions.dart
@@ -13,9 +13,9 @@ extension PointExtensions on Point {
   );
 
   Map<String, dynamic> toJson() => {
-    'x': x,
-    'y': y,
-    'p': p,
+    'x': double.parse((x).toStringAsFixed(4)),
+    'y': double.parse((y).toStringAsFixed(4)),
+    'p': double.parse((p).toStringAsFixed(8)),
   };
 
   Point operator +(Offset offset) => Point(


### PR DESCRIPTION
This reduces the file size of saved notes by decreasing the precision of the coordinates and the pressure of all points. Previously, the coordinates were saved with a precision of about 14 decimal places and the pressure with about 16. I reduced them to 4 and 8 and wasn't able to notice any differences regarding the quality. A note, that was 2.5 MB before, is now about 1 MB. Old notes with higher precision can still be opened normally.