### PR TITLE
feat: import pdf from home menu

### DIFF
--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -2,6 +2,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:go_router/go_router.dart';
+import 'package:printing/printing.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';
@@ -59,7 +60,7 @@ class _NewNoteButtonState extends State<NewNoteButton>{
           onTap: () async {
             final result = await FilePicker.platform.pickFiles(
               type: FileType.any,
-              allowedExtensions: ['sbn', 'sbn2'],
+              allowedExtensions: ['sbn', 'sbn2', 'pdf'],
               allowMultiple: false,
               withData: false,
             );
@@ -72,6 +73,15 @@ class _NewNoteButtonState extends State<NewNoteButton>{
               FileManager.importFile(filePath, true);
             } else if (filePath.endsWith('.sbn2')){
               FileManager.importFile(filePath, false);
+            } else if (filePath.endsWith('.pdf')){
+              bool canRasterPdf = true;
+              Printing.info().then((info) {
+                canRasterPdf = info.canRaster;
+              });
+              if(canRasterPdf){
+                if (!mounted) return;
+                context.push(RoutePaths.editImportPdf(filePath));
+              }
             } else {
               throw 'Invalid file type';
             }

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -6,6 +6,7 @@ import 'package:printing/printing.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';
+import 'package:saber/pages/editor/editor.dart';
 
 class NewNoteButton extends StatefulWidget {
   const NewNoteButton({
@@ -74,14 +75,9 @@ class _NewNoteButtonState extends State<NewNoteButton>{
             } else if (filePath.endsWith('.sbn2')) {
               FileManager.importFile(filePath, false);
             } else if (filePath.endsWith('.pdf')) {
-              bool canRasterPdf = true;
-              Printing.info().then((info) {
-                canRasterPdf = info.canRaster;
-              });
-              if (canRasterPdf) {
-                if (!mounted) return;
-                context.push(RoutePaths.editImportPdf(filePath));
-              }
+              if (!Editor.canRasterPdf) return;
+              if (!mounted) return;
+              context.push(RoutePaths.editImportPdf(filePath));
             } else {
               throw 'Invalid file type';
             }

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -2,7 +2,6 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:go_router/go_router.dart';
-import 'package:printing/printing.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';

--- a/lib/components/home/new_note_button.dart
+++ b/lib/components/home/new_note_button.dart
@@ -69,16 +69,16 @@ class _NewNoteButtonState extends State<NewNoteButton>{
             final filePath = result.files.single.path;
             if (filePath == null) return;
 
-            if (filePath.endsWith('.sbn')){
+            if (filePath.endsWith('.sbn')) {
               FileManager.importFile(filePath, true);
-            } else if (filePath.endsWith('.sbn2')){
+            } else if (filePath.endsWith('.sbn2')) {
               FileManager.importFile(filePath, false);
-            } else if (filePath.endsWith('.pdf')){
+            } else if (filePath.endsWith('.pdf')) {
               bool canRasterPdf = true;
               Printing.info().then((info) {
                 canRasterPdf = info.canRaster;
               });
-              if(canRasterPdf){
+              if (canRasterPdf) {
                 if (!mounted) return;
                 context.push(RoutePaths.editImportPdf(filePath));
               }

--- a/lib/data/routes.dart
+++ b/lib/data/routes.dart
@@ -17,6 +17,9 @@ abstract class RoutePaths {
   static String editFilePath(String filePath) {
     return '$edit?path=${Uri.encodeQueryComponent(filePath)}';
   }
+  static String editImportPdf(String pdfPath) {
+    return '$edit?pdfPath=${Uri.encodeQueryComponent(pdfPath)}';
+  }
 }
 
 abstract class HomeRoutes {

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -100,6 +100,7 @@ class App extends StatefulWidget {
         path: RoutePaths.edit,
         builder: (context, state) => Editor(
           path: state.uri.queryParameters['path'],
+          pdfPath: state.uri.queryParameters['pdfPath'],
         ),
       ),
       GoRoute(

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:open_as_default/open_as_default.dart';
 import 'package:path_to_regexp/path_to_regexp.dart';
+import 'package:printing/printing.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:saber/components/canvas/invert_shader.dart';
 import 'package:saber/components/home/banner_ad_widget.dart';
@@ -38,6 +39,9 @@ Future<void> main() async {
     Prefs.url.waitUntilLoaded(),
     Prefs.allowInsecureConnections.waitUntilLoaded(),
     InvertShader.init(),
+    Printing.info().then((info) {
+      Editor.canRasterPdf = info.canRaster;
+    }),
   ]);
 
   AdState.init();

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -152,7 +152,7 @@ class EditorState extends State<Editor> {
     _assignKeybindings();
 
     if (widget.pdfPath != null) {
-      importPdf(widget.pdfPath!);
+      importPdfFromFilePath(widget.pdfPath!);
     }
 
     super.initState();
@@ -946,7 +946,7 @@ class EditorState extends State<Editor> {
 
   /// Prompts the user to pick a PDF to import.
   /// Returns whether a PDF was picked.
-  Future<bool> pickPdf() async {
+  Future<bool> importPdf() async {
     if (coreInfo.readOnly) return false;
     if (!Editor.canRasterPdf) return false;
 
@@ -959,10 +959,10 @@ class EditorState extends State<Editor> {
     if (result == null) return false;
 
     final PlatformFile file = result.files.single;
-    return importPdf(file.path!);
+    return importPdfFromFilePath(file.path!);
   }
 
-  Future<bool> importPdf(String path) async{
+  Future<bool> importPdfFromFilePath(String path) async{
     final File tempFile = File(path);
     final Uint8List fileContents;
     try {
@@ -1478,7 +1478,7 @@ class EditorState extends State<Editor> {
       }),
 
       pickPhotos: _pickPhotos,
-      importPdf: pickPdf,
+      importPdf: importPdf,
       canRasterPdf: Editor.canRasterPdf,
     );
   }

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -155,7 +155,7 @@ class EditorState extends State<Editor> {
       canRasterPdf = info.canRaster;
     });
 
-    if(widget.pdfPath != null){
+    if (widget.pdfPath != null) {
       importPdf(widget.pdfPath!);
     }
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -84,6 +84,9 @@ class Editor extends StatefulWidget {
     RegExp(RegExp.escape(Whiteboard.filePath)),
   ];
 
+  /// Whether the platform can rasterize a pdf
+  static bool canRasterPdf = true;
+
   @override
   State<Editor> createState() => EditorState();
 }
@@ -136,9 +139,6 @@ class EditorState extends State<Editor> {
 
   QuillStruct? lastFocusedQuill;
 
-  /// Whether the platform can rasterize a pdf
-  bool canRasterPdf = true;
-
   /// The tool that was used before switching to the eraser.
   Tool? tmpTool;
   /// If the stylus button is pressed, or was pressed during the current draw gesture.
@@ -150,10 +150,6 @@ class EditorState extends State<Editor> {
 
     _initAsync();
     _assignKeybindings();
-
-    Printing.info().then((info) {
-      canRasterPdf = info.canRaster;
-    });
 
     if (widget.pdfPath != null) {
       importPdf(widget.pdfPath!);
@@ -952,7 +948,7 @@ class EditorState extends State<Editor> {
   /// Returns whether a PDF was picked.
   Future<bool> pickPdf() async {
     if (coreInfo.readOnly) return false;
-    if (!canRasterPdf) return false;
+    if (!Editor.canRasterPdf) return false;
 
     final FilePickerResult? result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -1483,7 +1479,7 @@ class EditorState extends State<Editor> {
 
       pickPhotos: _pickPhotos,
       importPdf: pickPdf,
-      canRasterPdf: canRasterPdf,
+      canRasterPdf: Editor.canRasterPdf,
     );
   }
 

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -151,10 +151,6 @@ class EditorState extends State<Editor> {
     _initAsync();
     _assignKeybindings();
 
-    if (widget.pdfPath != null) {
-      importPdfFromFilePath(widget.pdfPath!);
-    }
-
     super.initState();
   }
   void _initAsync() async {
@@ -169,6 +165,10 @@ class EditorState extends State<Editor> {
     }
 
     await _initStrokes();
+
+    if (widget.pdfPath != null) {
+      await importPdfFromFilePath(widget.pdfPath!);
+    }
   }
   Future _initStrokes() async {
     coreInfo = await EditorCoreInfo.loadFromFilePath(coreInfo.filePath);


### PR DESCRIPTION
This makes it possible to import PDF files when selecting the "import note" option in the home menu and then selecting a PDF file in the file picker. This should also <s>fix #[771](https://github.com/adil192/saber/issues/771)</s> by setting the "withData" parameter in the file picker to false. 