### PR TITLE
feat: save points as BsonBinary

### DIFF
--- a/lib/components/canvas/_stroke.dart
+++ b/lib/components/canvas/_stroke.dart
@@ -71,7 +71,7 @@ class Stroke {
     required this.penType,
   });
 
-  Stroke.fromJson(Map<String, dynamic> json) :
+  Stroke.fromJson(Map<String, dynamic> json, int fileVersion) :
         _isComplete = json['f'],
         pageIndex = json['i'] ?? 0,
         penType = json['ty'] ?? (Pen).toString() {
@@ -79,10 +79,17 @@ class Stroke {
 
     final offset = Offset(json['ox'] ?? 0, json['oy'] ?? 0);
     final pointsJson = json['p'] as List<dynamic>;
-    points.insertAll(0, pointsJson.map((point) => PointExtensions.fromJson(
-      json: Map<String, dynamic>.from(point),
-      offset: offset,
-    )).toList());
+    if(fileVersion >= 13) {
+      points.insertAll(0, pointsJson.map((point) => PointExtensions.fromBsonBinary(
+        json: point,
+        offset: offset,
+      )).toList());
+    } else {
+      points.insertAll(0, pointsJson.map((point) => PointExtensions.fromJson(
+        json: Map<String, dynamic>.from(point),
+        offset: offset,
+      )).toList());
+    }
   }
   // json keys should not be the same as the ones in the StrokeProperties class
   Map<String, dynamic> toJson() {
@@ -92,12 +99,12 @@ class Stroke {
         if (isStraightLine && points.length > 1) {
           Point last = snapLineToRightAngle(points.first, points.last);
           return [
-            points.first.toJson(),
-            last.toJson(),
-            last.toJson(),
+            points.first.toBsonBinary(),
+            last.toBsonBinary(),
+            last.toBsonBinary(),
           ];
         }
-        return points.map((Point point) => point.toJson()).toList();
+        return points.map((Point point) => point.toBsonBinary()).toList();
       }(),
       'i': pageIndex,
       'ty': penType.toString(),

--- a/lib/components/canvas/_stroke.dart
+++ b/lib/components/canvas/_stroke.dart
@@ -85,6 +85,7 @@ class Stroke {
         offset: offset,
       )).toList());
     } else {
+      // ignore: deprecated_member_use_from_same_package
       points.insertAll(0, pointsJson.map((point) => PointExtensions.fromJson(
         json: Map<String, dynamic>.from(point),
         offset: offset,

--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -108,7 +108,7 @@ class EditorCoreInfo {
         assets: assets,
         readOnly: readOnly,
         onlyFirstPage: onlyFirstPage,
-        fileVersion: fileVersion
+        fileVersion: fileVersion,
       ),
       initialPageIndex: json['c'] as int?,
     )

--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -16,7 +16,7 @@ import 'package:worker_manager/worker_manager.dart';
 class EditorCoreInfo {
   /// The version of the file format.
   /// Increment this if earlier versions of the app can't satisfiably read the file.
-  static const int sbnVersion = 12;
+  static const int sbnVersion = 13;
   bool readOnly = false;
   bool readOnlyBecauseOfVersion = false;
 
@@ -108,6 +108,7 @@ class EditorCoreInfo {
         assets: assets,
         readOnly: readOnly,
         onlyFirstPage: onlyFirstPage,
+        fileVersion: fileVersion
       ),
       initialPageIndex: json['c'] as int?,
     )
@@ -145,6 +146,7 @@ class EditorCoreInfo {
     required List<Uint8List>? assets,
     required bool readOnly,
     required bool onlyFirstPage,
+    required int fileVersion,
   }) {
     if (pages == null || pages.isEmpty) return [];
     if (pages[0] is List) { // old format (list of [width, height])
@@ -162,6 +164,7 @@ class EditorCoreInfo {
           page as Map<String, dynamic>,
           assets: assets ?? const [],
           readOnly: readOnly,
+          fileVersion: fileVersion,
         ))
         .toList();
     }
@@ -197,6 +200,7 @@ class EditorCoreInfo {
       final strokes = EditorPage.parseStrokesJson(
         strokesJson,
         onlyFirstPage: onlyFirstPage,
+        fileVersion: fileVersion,
       );
       for (Stroke stroke in strokes) {
         if (onlyFirstPage) assert(stroke.pageIndex == 0);

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -70,12 +70,14 @@ class EditorPage extends Listenable {
   factory EditorPage.fromJson(Map<String, dynamic> json, {
     required List<Uint8List> assets,
     required bool readOnly,
+    required int fileVersion
   }) {
     return EditorPage(
       size: Size(json['w'] ?? defaultWidth, json['h'] ?? defaultHeight),
       strokes: parseStrokesJson(
         json['s'] as List?,
         onlyFirstPage: false,
+        fileVersion: fileVersion,
       ),
       images: parseImagesJson(
         json['i'] as List?,
@@ -145,11 +147,12 @@ class EditorPage extends Listenable {
 
   static List<Stroke> parseStrokesJson(List<dynamic>? strokes, {
     required bool onlyFirstPage,
+    required int fileVersion,
   }) => strokes
       ?.map((dynamic stroke) {
         final map = stroke as Map<String, dynamic>;
         if (onlyFirstPage && map['i'] > 0) return null;
-        return Stroke.fromJson(map);
+        return Stroke.fromJson(map, fileVersion);
       })
       .where((element) => element != null)
       .cast<Stroke>()

--- a/lib/data/editor/page.dart
+++ b/lib/data/editor/page.dart
@@ -70,7 +70,7 @@ class EditorPage extends Listenable {
   factory EditorPage.fromJson(Map<String, dynamic> json, {
     required List<Uint8List> assets,
     required bool readOnly,
-    required int fileVersion
+    required int fileVersion,
   }) {
     return EditorPage(
       size: Size(json['w'] ?? defaultWidth, json['h'] ?? defaultHeight),

--- a/lib/data/extensions/point_extensions.dart
+++ b/lib/data/extensions/point_extensions.dart
@@ -1,5 +1,7 @@
+import 'dart:typed_data';
 import 'dart:ui' show Offset;
 
+import 'package:bson/bson.dart';
 import 'package:perfect_freehand/perfect_freehand.dart';
 
 extension PointExtensions on Point {
@@ -12,12 +14,19 @@ extension PointExtensions on Point {
     json['p'] ?? 0.5,
   );
 
-  Map<String, dynamic> toJson() => {
-    'x': x,
-    'y': y,
-    if (p != 0.5)
-      'p': p,
-  };
+  static Point fromBsonBinary({
+    required BsonBinary json,
+    Offset offset = Offset.zero}) {
+    Float32List point = json.byteList.buffer.asFloat32List();
+    return Point(
+        point[0] + offset.dx,
+        point[1] + offset.dy,
+        point.length == 2 ? 0.5 : point[2] 
+      );
+  } 
+
+  BsonBinary toBsonBinary() => 
+    BsonBinary.from(Float32List.fromList([x,y,if(p != 0.5) p]).buffer.asUint8List());
 
   Point operator +(Offset offset) => Point(
     x + offset.dx,

--- a/lib/data/extensions/point_extensions.dart
+++ b/lib/data/extensions/point_extensions.dart
@@ -16,17 +16,24 @@ extension PointExtensions on Point {
 
   static Point fromBsonBinary({
     required BsonBinary json,
-    Offset offset = Offset.zero}) {
+    Offset offset = Offset.zero,
+  }) {
     Float32List point = json.byteList.buffer.asFloat32List();
     return Point(
-        point[0] + offset.dx,
-        point[1] + offset.dy,
-        point.length == 2 ? 0.5 : point[2] 
-      );
-  } 
+      point[0] + offset.dx,
+      point[1] + offset.dy,
+      point.length == 2 ? 0.5 : point[2],
+    );
+  }
 
-  BsonBinary toBsonBinary() => 
-    BsonBinary.from(Float32List.fromList([x,y,if(p != 0.5) p]).buffer.asUint8List());
+  BsonBinary toBsonBinary() {
+    final Float32List point = Float32List.fromList([
+      x,
+      y,
+      if (p != 0.5) p,
+    ]);
+    return BsonBinary.from(point.buffer.asUint8List());
+  }
 
   Point operator +(Offset offset) => Point(
     x + offset.dx,

--- a/lib/data/extensions/point_extensions.dart
+++ b/lib/data/extensions/point_extensions.dart
@@ -5,6 +5,7 @@ import 'package:bson/bson.dart';
 import 'package:perfect_freehand/perfect_freehand.dart';
 
 extension PointExtensions on Point {
+  @Deprecated('Use fromBsonBinary instead; fromJson is only for backward compatibility')
   static Point fromJson({
     required Map<String, dynamic> json,
     Offset offset = Offset.zero,


### PR DESCRIPTION
This changes the way points are stored in BSON files. Previously, they were stored using the double format in BSON (8 Bytes per value, so 24 for each point (16, if the pressure is not stored)). When converting them to a Float32List and storing that into a BsonBinary value, this gets reduced to 4 Bytes per value, so 12 for each point (8 without pressure) and also now the names of these values 'x', 'y' and 'p' are not stored anymore, which should reduce the file size further. In total, this reduces the file size of a standard handwritten note by about 50%. Old notes can still be opened normally.