### PR TITLE
fix: allow files and folders with the same name

### DIFF
--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -276,7 +276,7 @@ class FileManager {
       .toList();
 
     await Future.wait(allChildren.map((child) async {
-      if (await FileManager.isDirectory(directory + child)) {
+      if (await FileManager.isDirectory(directory + child) && !directories.contains(child)) {
         directories.add(child);
       } else {
         files.add(child);


### PR DESCRIPTION
This fixes [#861 ](https://github.com/adil192/saber/issues/861) by checking if an entry for a directory that has the same name as a note already exists before adding such an entry, so that an entry for the note is also created.