### PR TITLE
fix: save exported files as .sbn2 instead of .sbn

### DIFF
--- a/lib/components/toolbar/export_bar.dart
+++ b/lib/components/toolbar/export_bar.dart
@@ -57,7 +57,7 @@ class _ExportBarState extends State<ExportBar> {
 
       TextButton(
         onPressed: _onPressed(widget.exportAsSbn),
-        child: _buttonChild(widget.exportAsSbn, 'SBN'),
+        child: _buttonChild(widget.exportAsSbn, 'SBN2'),
       ),
       TextButton(
         onPressed: _onPressed(widget.exportAsPdf),

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1094,7 +1094,7 @@ class EditorState extends State<Editor> {
   }
   Future exportAsSbn() async {
     final content = _saveToBinary();
-    await FileManager.exportFile('$_filename.sbn', content);
+    await FileManager.exportFile('$_filename.sbn2', content);
   }
 
   void setAndroidNavBarColor() async {

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -1094,7 +1094,7 @@ class EditorState extends State<Editor> {
   }
   Future exportAsSbn() async {
     final content = _saveToBinary();
-    await FileManager.exportFile('$_filename.sbn2', content);
+    await FileManager.exportFile('$_filename${Editor.extension}', content);
   }
 
   void setAndroidNavBarColor() async {


### PR DESCRIPTION
When exporting a note by using the "export as: SBN" button in the export menu, it was stored as a .sbn file instead of .sbn2, which made it impossible to reopen it without renaming. This changes the file extension to .sbn2.