### PR TITLE
feat: store images as BsonBinary

### DIFF
--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -19,7 +19,7 @@ class EditorCoreInfo {
 
   /// The version of the file format.
   /// Increment this if earlier versions of the app can't satisfiably read the file.
-  static const int sbnVersion = 13;
+  static const int sbnVersion = 14;
   bool readOnly = false;
   bool readOnlyBecauseOfVersion = false;
 
@@ -88,9 +88,13 @@ class EditorCoreInfo {
     bool readOnlyBecauseOfVersion = fileVersion > sbnVersion;
     readOnly = readOnly || readOnlyBecauseOfVersion;
 
-    List<Uint8List>? assets = (json['a'] as List<dynamic>?)
-        ?.map((base64) => base64Decode(base64 as String))
-        .toList();
+    List<Uint8List>? assets = fileVersion <= 13
+        ? (json['a'] as List<dynamic>?)
+            ?.map((base64) => base64Decode(base64 as String))
+            .toList()
+        : (json['a'] as List<dynamic>?)
+            ?.map((asset) => (asset as BsonBinary).byteList.buffer.asUint8List())
+            .toList();
 
     return EditorCoreInfo._(
       filePath: filePath,
@@ -384,7 +388,7 @@ class EditorCoreInfo {
       'c': initialPageIndex,
     };
 
-    json['a'] = assets.map((Uint8List asset) => base64Encode(asset)).toList();
+    json['a'] = assets.map((Uint8List asset) => BsonBinary.from(asset.buffer.asUint8List())).toList();
 
     return json;
   }

--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -95,7 +95,7 @@ class EditorCoreInfo {
             .toList()
         : (json['a'] as List<dynamic>?)
             ?.cast<BsonBinary>()
-            .map((asset) => asset.byteList.buffer.asUint8List())
+            .map((asset) => asset.byteList)
             .toList();
 
     return EditorCoreInfo._(
@@ -390,8 +390,7 @@ class EditorCoreInfo {
       'c': initialPageIndex,
     };
 
-    json['a'] = assets.map((Uint8List asset) => BsonBinary.from(asset.buffer.asUint8List())).toList();
-
+    json['a'] = assets.map((Uint8List asset) => BsonBinary.from(asset)).toList();
     return json;
   }
 

--- a/lib/data/editor/editor_core_info.dart
+++ b/lib/data/editor/editor_core_info.dart
@@ -90,10 +90,12 @@ class EditorCoreInfo {
 
     List<Uint8List>? assets = fileVersion <= 13
         ? (json['a'] as List<dynamic>?)
-            ?.map((base64) => base64Decode(base64 as String))
+            ?.cast<String>()
+            .map((base64) => base64Decode(base64))
             .toList()
         : (json['a'] as List<dynamic>?)
-            ?.map((asset) => (asset as BsonBinary).byteList.buffer.asUint8List())
+            ?.cast<BsonBinary>()
+            .map((asset) => asset.byteList.buffer.asUint8List())
             .toList();
 
     return EditorCoreInfo._(


### PR DESCRIPTION
This changes the way images are stored in .sbn2 files. Previously they were stored as an base64 encoded string. The BsonBinary format is about 25% more space efficient and should also be slighty faster than encoding the images in base64.