### PR TITLE
Created Step 0 in Line 182 strings.i18n.yaml

### DIFF
--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -319,7 +319,8 @@ hu:
         a: "Go to your server website and log in. Then go to Settings > Security > Change password. You'll need to log out and log back in to Saber after changing your password."
       - q: "How do I change my encryption password?"
         a: |-
-          1. Log out of Saber. Make sure syncing is complete before logging out so you don't lose any data (see the sync progress on the home screen).
+          0. Make sure syncing is complete (see the sync progress on the home screen).
+          1. Log out of Saber.
           2. Go to your server website and delete your 'Saber' folder. This will delete all your notes from the server.
           3. Log back in to Saber. You can choose a new encryption password when logging in.
           4. Don't forget to log out and log back in to Saber on your other devices too.

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 15
 /// Strings: 3585 (239 per locale)
 ///
-/// Built on 2023-09-19 at 15:27 UTC
+/// Built on 2023-09-19 at 15:46 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -697,7 +697,7 @@ class _StringsProfile$faq$0i2$En {
 
 	// Translations
 	String get q => 'How do I change my encryption password?';
-	String get a => '1. Log out of Saber. Make sure syncing is complete before logging out so you don\'t lose any data (see the sync progress on the home screen).\n2. Go to your server website and delete your \'Saber\' folder. This will delete all your notes from the server.\n3. Log back in to Saber. You can choose a new encryption password when logging in.\n4. Don\'t forget to log out and log back in to Saber on your other devices too.';
+	String get a => '0. Make sure syncing is complete (see the sync progress on the home screen).\n1. Log out of Saber.\n2. Go to your server website and delete your \'Saber\' folder. This will delete all your notes from the server.\n3. Log back in to Saber. You can choose a new encryption password when logging in.\n4. Don\'t forget to log out and log back in to Saber on your other devices too.';
 }
 
 // Path: profile.faq.3

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -179,7 +179,7 @@ profile:
       a: "Go to your server website and log in. Then go to Settings > Security > Change password. You'll need to log out and log back in to Saber after changing your password."
     - q: "How do I change my encryption password?"
       a: |-
-        0. Make sure syncing is complete before logging out so you don't lose any data (see the sync progress on the home screen).
+        0. Make sure syncing is complete (see the sync progress on the home screen).
         1. Log out of Saber.
         2. Go to your server website and delete your 'Saber' folder. This will delete all your notes from the server.
         3. Log back in to Saber. You can choose a new encryption password when logging in.

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -179,7 +179,8 @@ profile:
       a: "Go to your server website and log in. Then go to Settings > Security > Change password. You'll need to log out and log back in to Saber after changing your password."
     - q: "How do I change my encryption password?"
       a: |-
-        1. Log out of Saber. Make sure syncing is complete before logging out so you don't lose any data (see the sync progress on the home screen).
+        0. Make sure syncing is complete before logging out so you don't lose any data (see the sync progress on the home screen).
+        1. Log out of Saber.
         2. Go to your server website and delete your 'Saber' folder. This will delete all your notes from the server.
         3. Log back in to Saber. You can choose a new encryption password when logging in.
         4. Don't forget to log out and log back in to Saber on your other devices too.


### PR DESCRIPTION
Fixed the instructions regarding "How do I change my encryption password?" in Line 180.

The old instructions make a crucial mistake of saying "do this", and afterwards saying "do this first".

I propose to create Step 0. This indicates, that this is an optional prerequisite, but should at least be read before simply logging out. Thus, the possibility of reading this instruction and missing this "backup-step" is lowered.