### PR TITLE
i18n: Update German

### DIFF
--- a/lib/i18n/community/strings_de.i18n.yaml
+++ b/lib/i18n/community/strings_de.i18n.yaml
@@ -191,7 +191,7 @@ profile:
         Wenn du einen anderen Server nutzt, kann es sein, dass du deinen Account nicht löschen kannst: Für mehr Information kannst du in der Datenschutzbestimmung des Servers nachgucken.
 appInfo:
   licenseNotice: |-
-    Saber Copyright © 2022-$buildYear Adil Hanney
+    Saber  Copyright (C) 2022-$buildYear  Adil Hanney
     Dieses Programm kommt ohne jegliche Gewährleistung. Dies ist freie Software und du bist herzlich eingeladen, diese unter bestimmten Bedingungen weiterzuverteilen.
   dirty: TESTVERSION
   debug: DEBUG

--- a/lib/i18n/community/strings_de.i18n.yaml
+++ b/lib/i18n/community/strings_de.i18n.yaml
@@ -17,14 +17,14 @@ home:
   createNewNote: "Drücke die + Schaltfläche, um eine neue Notiz zu erstellen"
   newFolder:
     newFolder: Neuer Ordner
-    folderName: Ordner Name
+    folderName: Ordnername
     create: Erstellen
     folderNameEmpty: Ordnername darf nicht leer sein
     folderNameContainsSlash: Ordnernamen dürfen keine Schrägstriche enthalten
     folderNameExists: Ordner existiert bereits
   renameNote:
     renameNote: Notiz umbenennen
-    noteName: Notiz Name
+    noteName: Name der Notiz
     rename: Umbenennen
     noteNameEmpty: Name der Notiz darf nicht leer sein
     noteNameContainsSlash: Name der Notiz darf keinen Schrägstrich enthalten
@@ -39,15 +39,15 @@ home:
     deleteName(OUTDATED): Löschen Sie $f
     deleteFolder(OUTDATED): Lösche Ordner
     delete(OUTDATED): Löschen
-    alsoDeleteContents(OUTDATED): Löschen Sie außerdem alle Notizen in diesem Ordner
+    alsoDeleteContents(OUTDATED): Lösche außerdem alle Notizen in diesem Ordner
   deleteNote(OUTDATED): Notiz löschen
   create:
-    newNote(OUTDATED): Neuer Hinweis
+    newNote(OUTDATED): Neue Notiz
     importNote(OUTDATED): Notiz importieren
-  invalidFormat(OUTDATED): "Die von Ihnen ausgewählte Datei wird nicht unterstützt. Bitte wählen Sie eine .sbn-, .sbn2- oder .pdf-Datei aus."
+  invalidFormat(OUTDATED): "Die ausgewählte Datei wird nicht unterstützt. Bitte wähle eine .sbn-, .sbn2- oder .pdf-Datei aus."
   renameFolder:
     folderNameEmpty(OUTDATED): Der Ordnername darf nicht leer sein
-    renameFolder(OUTDATED): Rename Ordner
+    renameFolder(OUTDATED): Ordner umbenennen
     folderName(OUTDATED): Ordnernamen
     rename(OUTDATED): Name
     folderNameContainsSlash(OUTDATED): Der Ordnername darf keinen Schrägstrich enthalten
@@ -56,13 +56,13 @@ settings:
   prefCategories:
     general: Allgemein
     writing: Eingabe
-    advanced(OUTDATED): Fortschrittlich
+    advanced(OUTDATED): Fortgeschritten
     editor(OUTDATED): Herausgeber
   prefLabels:
     locale: Sprache
     appTheme: Anwendungsthema
     platform: Oberfläche
-    layoutSize: Layout Größe
+    layoutSize: Größe des Layouts
     customAccentColor: Benutzerdefinierte Akzentfarbe
     hyperlegibleFont: Hyperlesbare Schrift
     shouldCheckForUpdates: Suche automatisch nach Saber-Aktualisierungen
@@ -82,27 +82,27 @@ settings:
     dontSavePresetColors: Farbvorlagen nicht in den zuletzt genutzten Farben speichern
     printPageIndicators: Seitennummerierung drucken
     autosaveDelay(OUTDATED): Verzögerung beim automatischen Speichern
-    hideFingerDrawingToggle(OUTDATED): Blenden Sie den Fingerzeichnungsschalter aus
+    hideFingerDrawingToggle(OUTDATED): Den Fingerzeichnungsschalter ausblenden
     shouldAlwaysAlertForUpdates(OUTDATED): Schnellere Updates
     disableEraserAfterUse(OUTDATED): Deaktivieren Sie den Radierer automatisch
   prefDescriptions:
     hyperlegibleFont: Atkinson Hyperlegible verbessert die Lesbarkeit für Menschen mit eingeschränkter Sicht
-    disableAds: Die Entwicklung von Saber wird duch Webung finanziert. Die Werbung kann auf Wunsch deaktiviert werden.
+    disableAds: Die Entwicklung von Saber wird duch Werbung finanziert. Die Werbung kann auf Wunsch deaktiviert werden.
     allowInsecureConnections: (Nicht empfohlen) Saber erlauben sich mit selbstsignierten/unsicheren Zertifikaten zu verbinden
     editorOpaqueBackgrounds: Hintergrundbilder und PDFs undurchsichtig machen
     preferGreyscale: Für E-Ink-Bildschirme
     autoClearWhiteboardOnExit: Es wird dennoch mit deinen anderen Geräten synchronisiert
     maxImageSize: "Bilder, die größer sind, werden komprimiert"
-    editorPromptRename: Notizen können immer auch später noch umbenannt werden
+    editorPromptRename: Notizen können später immer noch umbenannt werden
     hideHomeBackgrounds: Für ein sauberes Aussehen
     printPageIndicators: Seitennummerierung bei Export anzeigen
-    autosaveDelay(OUTDATED): "Wie lange warten Sie, bevor Sie eine Notiz automatisch speichern"
+    autosaveDelay(OUTDATED): "Wartezeit, bevor eine Notiz automatisch gespeichert wird"
     hideFingerDrawing:
-      fixedOn(OUTDATED): Das Fingerzeichnen ist als aktiviert festgelegt
-      fixedOff(OUTDATED): Das Fingerzeichnen ist als deaktiviert behoben
+      fixedOn(OUTDATED): Das Fingerzeichnen ist derzeit aktiviert
+      fixedOff(OUTDATED): Das Fingerzeichnen ist derzeit deaktiviert
       shown(OUTDATED): Verhindert versehentliches Umschalten
     disableEraserAfterUse(OUTDATED): Schaltet nach Verwendung des Radiergummis automatisch wieder auf den Stift zurück
-    shouldAlwaysAlertForUpdates(OUTDATED): "Informieren Sie mich über Updates, sobald sie verfügbar sind"
+    shouldAlwaysAlertForUpdates(OUTDATED): "Informiere mich über Updates, sobald sie verfügbar sind"
   themeModes:
     system: System
     light: Hell
@@ -134,7 +134,7 @@ login:
     enterEncPassword: Bitte gib dein Verschlüsselungspasswort ein.
     checkUrl: Bitte gib eine gültige URL an.
     ncLoginFailed: "Anmeldung fehlgeschlagen, bitte überprüfe deine Angaben und deine Netzwerkverbindung."
-    ncUnsupportedFailure: "Der angegebene Nextcloud Server nutzt Version $v, aber diese Version von Saber unterstützt nur Nextcloud $s."
+    ncUnsupportedFailure: "Der angegebene Nextcloud-Server nutzt Version $v, aber diese Version von Saber unterstützt nur Nextcloud $s."
     encLoginFailed: "Anmeldung fehlgeschlagen, bitte überprüfe dein Verschlüsselungspasswort."
     loginSuccess: "Anmeldung erfolgreich! Bitte warte, während wir alles einrichten..."
   form:
@@ -152,45 +152,46 @@ login:
     tapToLogin: "Hier tippen, um dich mit Nextcloud anzumelden"
   faq:
     - q: "Was ist Nextcloud?"
-      a: "Nextcloud ist unter andrem ein privater Dateisynchronisationsserver. Du kannst den Standard-Saber-Nextcloud-Server, einen Drittanbieter-, oder einen selbst-gehosteten Server verwenden, um volle Kontrolle über deine Daten zu behalten."
+      a: "Nextcloud ist unter anderem ein privater Dateisynchronisationsserver. Du kannst den Standard-Saber-Nextcloud-Server, einen Drittanbieter-, oder einen selbst-gehosteten Server verwenden, um volle Kontrolle über deine Daten zu behalten."
     - q: "Was ist das Verchlüsselungspasswort?"
       a: |-
-        Das Verschlüsselungspassort wird verwendet, um deine Daten zu verschlüsseln, bevor diese an den Server gesendet werden. Es wird nicht auf dem Server gespeichert und nur von Saber verwendet, um deine Daten zu ver- und entschlüsseln.
+        Das Verschlüsselungspasswort wird verwendet, um deine Daten zu verschlüsseln, bevor diese an den Server gesendet werden. Es wird nicht auf dem Server gespeichert und nur von Saber verwendet, um deine Daten zu ver- und entschlüsseln.
         Niemand kann ohne dieses Passwort auf deine Notizen auf dem Server zugreifen. Das bedeutet allerdings auch, dass du, wenn du dein Verschlüsselungspasswort vergisst, den Zugriff auf deine Daten verlierst.
     - q: "Wieso zwei Passwörter?"
       a: |-
-        Das Nextcloud-Passwort wird verwendet, um auf die Cloud zuzugreifen. Das Verschlüsselungspasswort "verwürfelt" deine Daten, bevor diese die Cloud erreichen.
+        Das Nextcloud-Passwort wird verwendet, um auf die Cloud zuzugreifen. Das Verschlüsselungspasswort „verwürfelt“ deine Daten, bevor diese die Cloud erreichen.
         Selbst wenn jemand Zugriff zu deinem Nextcloud-Konto erlangt, bleiben deine Notizen sicher und verschlüsselt mit einem seperaten Passwort. Dies stellt eine zweite Sicherheitsebene zum Schutz deiner Daten dar.
     - q: "Wie melde ich mich an, wenn ich Zwei-Faktor-Authentifikation verwende?"
-      a: "Anstatt dein normales Nextcloud Password zu verwenden, musst du ein \"App Password\" erstellen. Das kannst du in den Nextcloud Einstellungen unter Sicherheit > Geräte & Sitzungen > Neues App-Passwort erstellen tun. Das betrifft dein Verschlüsselungspassword nicht."
+      a: "Anstatt dein normales Nextcloud-Passwort zu verwenden, musst du ein \"App Password\" erstellen. Das kannst du in den Nextcloud-Einstellungen unter Sicherheit > Geräte & Sitzungen > Neues App-Passwort erstellen tun. Das betrifft nicht dein Verschlüsselungspasswort."
     - q: "Kann ich dasselbe Passwort für beide verwenden?"
-      a: "Ja, aber das ist nicht so sicher. Da dein Nextcloud Passwort an den Server übertragen wird, kann jemand mit Zugriff auf den Server deine Notizen entschlüsseln. Du solltest also nur dasselbe Password verwenden, wenn du der Person, die den Server besitzt, vertraust."
+      a: "Ja, aber das ist nicht so sicher. Da dein Nextcloud-Passwort an den Server übertragen wird, kann jemand mit Zugriff auf den Server deine Notizen entschlüsseln. Du solltest also nur dasselbe Passwort verwenden, wenn du der Person, die den Server besitzt, vertraust."
 profile:
   title: Mein Profil
   logout: Abmelden
   quickLinks:
     title: Schnellzugriff
-    serverHomepage: Server Startseite
-    deleteAccount: Account Löschen
+    serverHomepage: Server-Startseite
+    deleteAccount: Account löschen
   faq:
     - q: "Verliere ich meine Notizen, wenn ich mich abmelde?"
-      a: "Nein. Deine Notizen bleiben auf deinem Gerät und auf dem Server. Sie werden erst wieder synchronisiert, wenn du dich erneut anmeldest. Um Datenverlust zu vermeiden, solltest du sicherstellen, dass alles korrekt synchronisiert wurde, bevor du dich abmeldest. Dazu kannst du auf dem Startbildschirm den Synchronisationsfortschritt anschauen."
-    - q: "Wie  ändere ich mein Nextcloud Passwort?"
-      a: "Öffne die Server Website und melde dich an. Unter Einstellungen>Sicherheit>Passwort, kannst du dein Passwort ändern. Nachdem du dein Passwort geändert hast, musst du dich in der App abmelden und wieder anmelden."
+      a: "Nein. Deine Notizen bleiben auf deinem Gerät und auf dem Server. Sie werden erst wieder synchronisiert, wenn du dich erneut anmeldest. Um Datenverlust zu vermeiden, solltest du sicherstellen, dass alles korrekt synchronisiert wurde, bevor du dich abmeldest. Dazu kannst du auf dem Startbildschirm den Synchronisationsfortschritt überprüfen."
+    - q: "Wie ändere ich mein Nextcloud-Passwort?"
+      a: "Öffne die Server-Startseite und melde dich an. Unter Einstellungen > Sicherheit > Passwort, kannst du dein Passwort ändern. Nachdem du dein Passwort geändert hast, musst du dich in Saber ab- und wieder anmelden."
     - q: "Wie ändere ich mein Verschlüsselungspasswort?"
       a: |-
-        1. Melde dich in Saber ab. Bitte stelle vorher sicher, dass alle Daten korrekt synchronisiert wurden, damit du keine Daten verlierst (du kannst den Fortschritt auf dem Startbildschirm prüfen).
-        2. Öffne die Server Website und lösche den 'Saber' Order. Dadurch werden alle Notizen vom Server gelöscht.
+        0. Bitte stelle zuerst sicher, dass alle Daten korrekt synchronisiert wurden, damit du keine Daten verlierst (du kannst den Fortschritt auf dem Startbildschirm prüfen).
+        1. Melde dich in Saber ab. 
+        2. Öffne die Server-Startseite und lösche den „Saber“-Order. Dadurch werden alle Notizen vom Server gelöscht.
         3. Melde dich wieder in Saber an. Du wirst nach einem neuen Verschlüsselungspasswort gefragt.
-        4. Vergiss nicht auf anderen Geräten dich in Saber ab- und wieder anzumelden.
+        4. Vergiss nicht dich auf anderen Geräten in Saber ab- und wieder anzumelden.
     - q: "Wie lösche ich meinen Account?"
       a: |-
-        Drücke den  "@:profile.quickLinks.deleteAccount" Knopf oben und melde dich an (solltest du gefragt werden).
-        Wenn du den offiziellen Saber Server nutzt, wird dein Account automatisch nach einer Woche gelöscht. Während dieser Woche, kannst du mich unter adilhanney@disroot.org kontaktieren.
+        Drücke oben den „@:profile.quickLinks.deleteAccount“-Button und melde dich gegebenenfalls an.
+        Wenn du den offiziellen Saber-Server nutzt, wird dein Account automatisch nach einer Woche gelöscht. Du kannst mich während dieser Woche unter adilhanney@disroot.org kontaktieren um die Löschung rückgängig zu machen.
         Wenn du einen anderen Server nutzt, kann es sein, dass du deinen Account nicht löschen kannst: Für mehr Information kannst du in der Datenschutzbestimmung des Servers nachgucken.
 appInfo:
   licenseNotice: |-
-    Saber  Copyright (C) 2022-$buildYear  Adil Hanney
+    Saber Copyright © 2022-$buildYear Adil Hanney
     Dieses Programm kommt ohne jegliche Gewährleistung. Dies ist freie Software und du bist herzlich eingeladen, diese unter bestimmten Bedingungen weiterzuverteilen.
   dirty: TESTVERSION
   debug: DEBUG
@@ -221,7 +222,7 @@ editor:
     laserPointer: Laserpointer
   penOptions:
     size: Dicke
-    sizeDragHint: "Nach links oder rechts ziehen, um die Größe zu ändern"
+    sizeDragHint: "Nach links oder rechts ziehen, um die Dicke zu ändern"
   colors:
     colorPicker: Farbauswahl
     black: Schwarz
@@ -235,7 +236,7 @@ editor:
     yellow: Gelb
     purple: Lila
     orange: Orange
-    pastelRed: Pastellfarbenes rot
+    pastelRed: Pastellfarbenes Rot
     pastelOrange: Pastellfarbenes Orange
     pastelYellow: Pastellfarbenes Gelb
     pastelGreen: Pastellfarbenes Grün
@@ -257,7 +258,7 @@ editor:
     duplicatePage: Seite duplizieren
     deletePage: Seite löschen
     lineHeight: Zeilenhöhe
-    lineHeightDescription: Beeinflusst die Schriftgröße
+    lineHeightDescription: Beeinflusst außerdem die Schriftgröße
     backgroundImageFit(OUTDATED): Hintergrundbild
     backgroundPattern: Hintergrundmuster
     import: Importieren
@@ -288,7 +289,7 @@ editor:
     lockZoom: Zoom sperren
     unlockSingleFingerPan: Verschieben mit einem Finger aktivieren
     lockSingleFingerPan: Verschieben mit einem Finger deaktivieren
-    unlockAxisAlignedPan: Beschränkung der Horizontal bzw. Vertikalverschiebung aufheben
+    unlockAxisAlignedPan: Beschränkung der Horizontal- bzw. Vertikalverschiebung aufheben
     lockAxisAlignedPan: Verschieben auf Horizontale oder Vertikale beschränken
   pages: Seiten
   untitled: Unbenannt

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 15
 /// Strings: 3585 (239 per locale)
 ///
-/// Built on 2023-09-11 at 22:44 UTC
+/// Built on 2023-09-19 at 15:27 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2483,7 +2483,7 @@ class _StringsHomeDe extends _StringsHomeEn {
 	@override late final _StringsHomeDeleteFolderDe deleteFolder = _StringsHomeDeleteFolderDe._(_root);
 	@override String get deleteNote => 'Notiz löschen';
 	@override late final _StringsHomeCreateDe create = _StringsHomeCreateDe._(_root);
-	@override String get invalidFormat => 'Die von Ihnen ausgewählte Datei wird nicht unterstützt. Bitte wählen Sie eine .sbn-, .sbn2- oder .pdf-Datei aus.';
+	@override String get invalidFormat => 'Die ausgewählte Datei wird nicht unterstützt. Bitte wähle eine .sbn-, .sbn2- oder .pdf-Datei aus.';
 	@override late final _StringsHomeRenameFolderDe renameFolder = _StringsHomeRenameFolderDe._(_root);
 }
 
@@ -2647,7 +2647,7 @@ class _StringsHomeNewFolderDe extends _StringsHomeNewFolderEn {
 
 	// Translations
 	@override String get newFolder => 'Neuer Ordner';
-	@override String get folderName => 'Ordner Name';
+	@override String get folderName => 'Ordnername';
 	@override String get create => 'Erstellen';
 	@override String get folderNameEmpty => 'Ordnername darf nicht leer sein';
 	@override String get folderNameContainsSlash => 'Ordnernamen dürfen keine Schrägstriche enthalten';
@@ -2662,7 +2662,7 @@ class _StringsHomeRenameNoteDe extends _StringsHomeRenameNoteEn {
 
 	// Translations
 	@override String get renameNote => 'Notiz umbenennen';
-	@override String get noteName => 'Notiz Name';
+	@override String get noteName => 'Name der Notiz';
 	@override String get rename => 'Umbenennen';
 	@override String get noteNameEmpty => 'Name der Notiz darf nicht leer sein';
 	@override String get noteNameContainsSlash => 'Name der Notiz darf keinen Schrägstrich enthalten';
@@ -2692,7 +2692,7 @@ class _StringsHomeDeleteFolderDe extends _StringsHomeDeleteFolderEn {
 	@override String deleteName({required Object f}) => 'Löschen Sie ${f}';
 	@override String get deleteFolder => 'Lösche Ordner';
 	@override String get delete => 'Löschen';
-	@override String get alsoDeleteContents => 'Löschen Sie außerdem alle Notizen in diesem Ordner';
+	@override String get alsoDeleteContents => 'Lösche außerdem alle Notizen in diesem Ordner';
 }
 
 // Path: home.create
@@ -2702,7 +2702,7 @@ class _StringsHomeCreateDe extends _StringsHomeCreateEn {
 	@override final _StringsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get newNote => 'Neuer Hinweis';
+	@override String get newNote => 'Neue Notiz';
 	@override String get importNote => 'Notiz importieren';
 }
 
@@ -2714,7 +2714,7 @@ class _StringsHomeRenameFolderDe extends _StringsHomeRenameFolderEn {
 
 	// Translations
 	@override String get folderNameEmpty => 'Der Ordnername darf nicht leer sein';
-	@override String get renameFolder => 'Rename Ordner';
+	@override String get renameFolder => 'Ordner umbenennen';
 	@override String get folderName => 'Ordnernamen';
 	@override String get rename => 'Name';
 	@override String get folderNameContainsSlash => 'Der Ordnername darf keinen Schrägstrich enthalten';
@@ -2730,7 +2730,7 @@ class _StringsSettingsPrefCategoriesDe extends _StringsSettingsPrefCategoriesEn 
 	// Translations
 	@override String get general => 'Allgemein';
 	@override String get writing => 'Eingabe';
-	@override String get advanced => 'Fortschrittlich';
+	@override String get advanced => 'Fortgeschritten';
 	@override String get editor => 'Herausgeber';
 }
 
@@ -2744,7 +2744,7 @@ class _StringsSettingsPrefLabelsDe extends _StringsSettingsPrefLabelsEn {
 	@override String get locale => 'Sprache';
 	@override String get appTheme => 'Anwendungsthema';
 	@override String get platform => 'Oberfläche';
-	@override String get layoutSize => 'Layout Größe';
+	@override String get layoutSize => 'Größe des Layouts';
 	@override String get customAccentColor => 'Benutzerdefinierte Akzentfarbe';
 	@override String get hyperlegibleFont => 'Hyperlesbare Schrift';
 	@override String get shouldCheckForUpdates => 'Suche automatisch nach Saber-Aktualisierungen';
@@ -2764,7 +2764,7 @@ class _StringsSettingsPrefLabelsDe extends _StringsSettingsPrefLabelsEn {
 	@override String get dontSavePresetColors => 'Farbvorlagen nicht in den zuletzt genutzten Farben speichern';
 	@override String get printPageIndicators => 'Seitennummerierung drucken';
 	@override String get autosaveDelay => 'Verzögerung beim automatischen Speichern';
-	@override String get hideFingerDrawingToggle => 'Blenden Sie den Fingerzeichnungsschalter aus';
+	@override String get hideFingerDrawingToggle => 'Den Fingerzeichnungsschalter ausblenden';
 	@override String get shouldAlwaysAlertForUpdates => 'Schnellere Updates';
 	@override String get disableEraserAfterUse => 'Deaktivieren Sie den Radierer automatisch';
 }
@@ -2777,19 +2777,19 @@ class _StringsSettingsPrefDescriptionsDe extends _StringsSettingsPrefDescription
 
 	// Translations
 	@override String get hyperlegibleFont => 'Atkinson Hyperlegible verbessert die Lesbarkeit für Menschen mit eingeschränkter Sicht';
-	@override String get disableAds => 'Die Entwicklung von Saber wird duch Webung finanziert. Die Werbung kann auf Wunsch deaktiviert werden.';
+	@override String get disableAds => 'Die Entwicklung von Saber wird duch Werbung finanziert. Die Werbung kann auf Wunsch deaktiviert werden.';
 	@override String get allowInsecureConnections => '(Nicht empfohlen) Saber erlauben sich mit selbstsignierten/unsicheren Zertifikaten zu verbinden';
 	@override String get editorOpaqueBackgrounds => 'Hintergrundbilder und PDFs undurchsichtig machen';
 	@override String get preferGreyscale => 'Für E-Ink-Bildschirme';
 	@override String get autoClearWhiteboardOnExit => 'Es wird dennoch mit deinen anderen Geräten synchronisiert';
 	@override String get maxImageSize => 'Bilder, die größer sind, werden komprimiert';
-	@override String get editorPromptRename => 'Notizen können immer auch später noch umbenannt werden';
+	@override String get editorPromptRename => 'Notizen können später immer noch umbenannt werden';
 	@override String get hideHomeBackgrounds => 'Für ein sauberes Aussehen';
 	@override String get printPageIndicators => 'Seitennummerierung bei Export anzeigen';
-	@override String get autosaveDelay => 'Wie lange warten Sie, bevor Sie eine Notiz automatisch speichern';
+	@override String get autosaveDelay => 'Wartezeit, bevor eine Notiz automatisch gespeichert wird';
 	@override late final _StringsSettingsPrefDescriptionsHideFingerDrawingDe hideFingerDrawing = _StringsSettingsPrefDescriptionsHideFingerDrawingDe._(_root);
 	@override String get disableEraserAfterUse => 'Schaltet nach Verwendung des Radiergummis automatisch wieder auf den Stift zurück';
-	@override String get shouldAlwaysAlertForUpdates => 'Informieren Sie mich über Updates, sobald sie verfügbar sind';
+	@override String get shouldAlwaysAlertForUpdates => 'Informiere mich über Updates, sobald sie verfügbar sind';
 }
 
 // Path: settings.themeModes
@@ -2861,7 +2861,7 @@ class _StringsLoginFeedbacksDe extends _StringsLoginFeedbacksEn {
 	@override String get enterEncPassword => 'Bitte gib dein Verschlüsselungspasswort ein.';
 	@override String get checkUrl => 'Bitte gib eine gültige URL an.';
 	@override String get ncLoginFailed => 'Anmeldung fehlgeschlagen, bitte überprüfe deine Angaben und deine Netzwerkverbindung.';
-	@override String ncUnsupportedFailure({required Object v, required Object s}) => 'Der angegebene Nextcloud Server nutzt Version ${v}, aber diese Version von Saber unterstützt nur Nextcloud ${s}.';
+	@override String ncUnsupportedFailure({required Object v, required Object s}) => 'Der angegebene Nextcloud-Server nutzt Version ${v}, aber diese Version von Saber unterstützt nur Nextcloud ${s}.';
 	@override String get encLoginFailed => 'Anmeldung fehlgeschlagen, bitte überprüfe dein Verschlüsselungspasswort.';
 	@override String get loginSuccess => 'Anmeldung erfolgreich! Bitte warte, während wir alles einrichten...';
 }
@@ -2906,7 +2906,7 @@ class _StringsLogin$faq$0i0$De extends _StringsLogin$faq$0i0$En {
 
 	// Translations
 	@override String get q => 'Was ist Nextcloud?';
-	@override String get a => 'Nextcloud ist unter andrem ein privater Dateisynchronisationsserver. Du kannst den Standard-Saber-Nextcloud-Server, einen Drittanbieter-, oder einen selbst-gehosteten Server verwenden, um volle Kontrolle über deine Daten zu behalten.';
+	@override String get a => 'Nextcloud ist unter anderem ein privater Dateisynchronisationsserver. Du kannst den Standard-Saber-Nextcloud-Server, einen Drittanbieter-, oder einen selbst-gehosteten Server verwenden, um volle Kontrolle über deine Daten zu behalten.';
 }
 
 // Path: login.faq.1
@@ -2917,7 +2917,7 @@ class _StringsLogin$faq$0i1$De extends _StringsLogin$faq$0i1$En {
 
 	// Translations
 	@override String get q => 'Was ist das Verchlüsselungspasswort?';
-	@override String get a => 'Das Verschlüsselungspassort wird verwendet, um deine Daten zu verschlüsseln, bevor diese an den Server gesendet werden. Es wird nicht auf dem Server gespeichert und nur von Saber verwendet, um deine Daten zu ver- und entschlüsseln.\nNiemand kann ohne dieses Passwort auf deine Notizen auf dem Server zugreifen. Das bedeutet allerdings auch, dass du, wenn du dein Verschlüsselungspasswort vergisst, den Zugriff auf deine Daten verlierst.';
+	@override String get a => 'Das Verschlüsselungspasswort wird verwendet, um deine Daten zu verschlüsseln, bevor diese an den Server gesendet werden. Es wird nicht auf dem Server gespeichert und nur von Saber verwendet, um deine Daten zu ver- und entschlüsseln.\nNiemand kann ohne dieses Passwort auf deine Notizen auf dem Server zugreifen. Das bedeutet allerdings auch, dass du, wenn du dein Verschlüsselungspasswort vergisst, den Zugriff auf deine Daten verlierst.';
 }
 
 // Path: login.faq.2
@@ -2928,7 +2928,7 @@ class _StringsLogin$faq$0i2$De extends _StringsLogin$faq$0i2$En {
 
 	// Translations
 	@override String get q => 'Wieso zwei Passwörter?';
-	@override String get a => 'Das Nextcloud-Passwort wird verwendet, um auf die Cloud zuzugreifen. Das Verschlüsselungspasswort "verwürfelt" deine Daten, bevor diese die Cloud erreichen.\nSelbst wenn jemand Zugriff zu deinem Nextcloud-Konto erlangt, bleiben deine Notizen sicher und verschlüsselt mit einem seperaten Passwort. Dies stellt eine zweite Sicherheitsebene zum Schutz deiner Daten dar.';
+	@override String get a => 'Das Nextcloud-Passwort wird verwendet, um auf die Cloud zuzugreifen. Das Verschlüsselungspasswort „verwürfelt“ deine Daten, bevor diese die Cloud erreichen.\nSelbst wenn jemand Zugriff zu deinem Nextcloud-Konto erlangt, bleiben deine Notizen sicher und verschlüsselt mit einem seperaten Passwort. Dies stellt eine zweite Sicherheitsebene zum Schutz deiner Daten dar.';
 }
 
 // Path: login.faq.3
@@ -2939,7 +2939,7 @@ class _StringsLogin$faq$0i3$De extends _StringsLogin$faq$0i3$En {
 
 	// Translations
 	@override String get q => 'Wie melde ich mich an, wenn ich Zwei-Faktor-Authentifikation verwende?';
-	@override String get a => 'Anstatt dein normales Nextcloud Password zu verwenden, musst du ein "App Password" erstellen. Das kannst du in den Nextcloud Einstellungen unter Sicherheit > Geräte & Sitzungen > Neues App-Passwort erstellen tun. Das betrifft dein Verschlüsselungspassword nicht.';
+	@override String get a => 'Anstatt dein normales Nextcloud-Passwort zu verwenden, musst du ein "App Password" erstellen. Das kannst du in den Nextcloud-Einstellungen unter Sicherheit > Geräte & Sitzungen > Neues App-Passwort erstellen tun. Das betrifft nicht dein Verschlüsselungspasswort.';
 }
 
 // Path: login.faq.4
@@ -2950,7 +2950,7 @@ class _StringsLogin$faq$0i4$De extends _StringsLogin$faq$0i4$En {
 
 	// Translations
 	@override String get q => 'Kann ich dasselbe Passwort für beide verwenden?';
-	@override String get a => 'Ja, aber das ist nicht so sicher. Da dein Nextcloud Passwort an den Server übertragen wird, kann jemand mit Zugriff auf den Server deine Notizen entschlüsseln. Du solltest also nur dasselbe Password verwenden, wenn du der Person, die den Server besitzt, vertraust.';
+	@override String get a => 'Ja, aber das ist nicht so sicher. Da dein Nextcloud-Passwort an den Server übertragen wird, kann jemand mit Zugriff auf den Server deine Notizen entschlüsseln. Du solltest also nur dasselbe Passwort verwenden, wenn du der Person, die den Server besitzt, vertraust.';
 }
 
 // Path: profile.quickLinks
@@ -2961,8 +2961,8 @@ class _StringsProfileQuickLinksDe extends _StringsProfileQuickLinksEn {
 
 	// Translations
 	@override String get title => 'Schnellzugriff';
-	@override String get serverHomepage => 'Server Startseite';
-	@override String get deleteAccount => 'Account Löschen';
+	@override String get serverHomepage => 'Server-Startseite';
+	@override String get deleteAccount => 'Account löschen';
 }
 
 // Path: profile.faq.0
@@ -2973,7 +2973,7 @@ class _StringsProfile$faq$0i0$De extends _StringsProfile$faq$0i0$En {
 
 	// Translations
 	@override String get q => 'Verliere ich meine Notizen, wenn ich mich abmelde?';
-	@override String get a => 'Nein. Deine Notizen bleiben auf deinem Gerät und auf dem Server. Sie werden erst wieder synchronisiert, wenn du dich erneut anmeldest. Um Datenverlust zu vermeiden, solltest du sicherstellen, dass alles korrekt synchronisiert wurde, bevor du dich abmeldest. Dazu kannst du auf dem Startbildschirm den Synchronisationsfortschritt anschauen.';
+	@override String get a => 'Nein. Deine Notizen bleiben auf deinem Gerät und auf dem Server. Sie werden erst wieder synchronisiert, wenn du dich erneut anmeldest. Um Datenverlust zu vermeiden, solltest du sicherstellen, dass alles korrekt synchronisiert wurde, bevor du dich abmeldest. Dazu kannst du auf dem Startbildschirm den Synchronisationsfortschritt überprüfen.';
 }
 
 // Path: profile.faq.1
@@ -2983,8 +2983,8 @@ class _StringsProfile$faq$0i1$De extends _StringsProfile$faq$0i1$En {
 	@override final _StringsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get q => 'Wie  ändere ich mein Nextcloud Passwort?';
-	@override String get a => 'Öffne die Server Website und melde dich an. Unter Einstellungen>Sicherheit>Passwort, kannst du dein Passwort ändern. Nachdem du dein Passwort geändert hast, musst du dich in der App abmelden und wieder anmelden.';
+	@override String get q => 'Wie ändere ich mein Nextcloud-Passwort?';
+	@override String get a => 'Öffne die Server-Startseite und melde dich an. Unter Einstellungen > Sicherheit > Passwort, kannst du dein Passwort ändern. Nachdem du dein Passwort geändert hast, musst du dich in Saber ab- und wieder anmelden.';
 }
 
 // Path: profile.faq.2
@@ -2995,7 +2995,7 @@ class _StringsProfile$faq$0i2$De extends _StringsProfile$faq$0i2$En {
 
 	// Translations
 	@override String get q => 'Wie ändere ich mein Verschlüsselungspasswort?';
-	@override String get a => '1. Melde dich in Saber ab. Bitte stelle vorher sicher, dass alle Daten korrekt synchronisiert wurden, damit du keine Daten verlierst (du kannst den Fortschritt auf dem Startbildschirm prüfen).\n2. Öffne die Server Website und lösche den \'Saber\' Order. Dadurch werden alle Notizen vom Server gelöscht.\n3. Melde dich wieder in Saber an. Du wirst nach einem neuen Verschlüsselungspasswort gefragt.\n4. Vergiss nicht auf anderen Geräten dich in Saber ab- und wieder anzumelden.';
+	@override String get a => '0. Bitte stelle zuerst sicher, dass alle Daten korrekt synchronisiert wurden, damit du keine Daten verlierst (du kannst den Fortschritt auf dem Startbildschirm prüfen).\n1. Melde dich in Saber ab. \n2. Öffne die Server-Startseite und lösche den „Saber“-Order. Dadurch werden alle Notizen vom Server gelöscht.\n3. Melde dich wieder in Saber an. Du wirst nach einem neuen Verschlüsselungspasswort gefragt.\n4. Vergiss nicht dich auf anderen Geräten in Saber ab- und wieder anzumelden.';
 }
 
 // Path: profile.faq.3
@@ -3006,7 +3006,7 @@ class _StringsProfile$faq$0i3$De extends _StringsProfile$faq$0i3$En {
 
 	// Translations
 	@override String get q => 'Wie lösche ich meinen Account?';
-	@override String get a => 'Drücke den  "${_root.profile.quickLinks.deleteAccount}" Knopf oben und melde dich an (solltest du gefragt werden).\nWenn du den offiziellen Saber Server nutzt, wird dein Account automatisch nach einer Woche gelöscht. Während dieser Woche, kannst du mich unter adilhanney@disroot.org kontaktieren.\nWenn du einen anderen Server nutzt, kann es sein, dass du deinen Account nicht löschen kannst: Für mehr Information kannst du in der Datenschutzbestimmung des Servers nachgucken.';
+	@override String get a => 'Drücke oben den „${_root.profile.quickLinks.deleteAccount}“-Button und melde dich gegebenenfalls an.\nWenn du den offiziellen Saber-Server nutzt, wird dein Account automatisch nach einer Woche gelöscht. Du kannst mich während dieser Woche unter adilhanney@disroot.org kontaktieren um die Löschung rückgängig zu machen.\nWenn du einen anderen Server nutzt, kann es sein, dass du deinen Account nicht löschen kannst: Für mehr Information kannst du in der Datenschutzbestimmung des Servers nachgucken.';
 }
 
 // Path: editor.toolbar
@@ -3050,7 +3050,7 @@ class _StringsEditorPenOptionsDe extends _StringsEditorPenOptionsEn {
 
 	// Translations
 	@override String get size => 'Dicke';
-	@override String get sizeDragHint => 'Nach links oder rechts ziehen, um die Größe zu ändern';
+	@override String get sizeDragHint => 'Nach links oder rechts ziehen, um die Dicke zu ändern';
 }
 
 // Path: editor.colors
@@ -3072,7 +3072,7 @@ class _StringsEditorColorsDe extends _StringsEditorColorsEn {
 	@override String get yellow => 'Gelb';
 	@override String get purple => 'Lila';
 	@override String get orange => 'Orange';
-	@override String get pastelRed => 'Pastellfarbenes rot';
+	@override String get pastelRed => 'Pastellfarbenes Rot';
 	@override String get pastelOrange => 'Pastellfarbenes Orange';
 	@override String get pastelYellow => 'Pastellfarbenes Gelb';
 	@override String get pastelGreen => 'Pastellfarbenes Grün';
@@ -3110,7 +3110,7 @@ class _StringsEditorMenuDe extends _StringsEditorMenuEn {
 	@override String get duplicatePage => 'Seite duplizieren';
 	@override String get deletePage => 'Seite löschen';
 	@override String get lineHeight => 'Zeilenhöhe';
-	@override String get lineHeightDescription => 'Beeinflusst die Schriftgröße';
+	@override String get lineHeightDescription => 'Beeinflusst außerdem die Schriftgröße';
 	@override String get backgroundImageFit => 'Hintergrundbild';
 	@override String get backgroundPattern => 'Hintergrundmuster';
 	@override String get import => 'Importieren';
@@ -3153,7 +3153,7 @@ class _StringsEditorHudDe extends _StringsEditorHudEn {
 	@override String get lockZoom => 'Zoom sperren';
 	@override String get unlockSingleFingerPan => 'Verschieben mit einem Finger aktivieren';
 	@override String get lockSingleFingerPan => 'Verschieben mit einem Finger deaktivieren';
-	@override String get unlockAxisAlignedPan => 'Beschränkung der Horizontal bzw. Vertikalverschiebung aufheben';
+	@override String get unlockAxisAlignedPan => 'Beschränkung der Horizontal- bzw. Vertikalverschiebung aufheben';
 	@override String get lockAxisAlignedPan => 'Verschieben auf Horizontale oder Vertikale beschränken';
 }
 
@@ -3164,8 +3164,8 @@ class _StringsSettingsPrefDescriptionsHideFingerDrawingDe extends _StringsSettin
 	@override final _StringsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get fixedOn => 'Das Fingerzeichnen ist als aktiviert festgelegt';
-	@override String get fixedOff => 'Das Fingerzeichnen ist als deaktiviert behoben';
+	@override String get fixedOn => 'Das Fingerzeichnen ist derzeit aktiviert';
+	@override String get fixedOff => 'Das Fingerzeichnen ist derzeit deaktiviert';
 	@override String get shown => 'Verhindert versehentliches Umschalten';
 }
 


### PR DESCRIPTION
* Fixed a lot of typos.
* Exchanged all formal references to informal references ("Du" instead of "Sie").
* Fixed many consistency issues
* Edited quotation marks („“ instead of "")
* Edited the FAQ regarding the change of the encryption password
* Changed the copyright symbol in the "About the app" section from (C) to ©
* Fixed many spacings (two spaces instead of one)