### PR TITLE
feat: select multiple notes to move/rename/delete

### DIFF
--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -26,11 +26,11 @@ class _MasonryFilesState extends State<MasonryFiles> {
   final List<String> selectedFiles = [];
   final ValueNotifier<bool> isAnythingSelected = ValueNotifier(false);
 
-  void toggleSelection(String filepath, bool selected) {
+  void toggleSelection(String filePath, bool selected) {
     if (selected) {
-      selectedFiles.add(filepath);
+      selectedFiles.add(filePath);
     } else {
-      selectedFiles.remove(filepath);
+      selectedFiles.remove(filePath);
     }
     isAnythingSelected.value = selectedFiles.isNotEmpty;
     widget.setSelectedFiles(selectedFiles);

--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -3,27 +3,47 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:saber/components/home/banner_ad_widget.dart';
 import 'package:saber/components/home/preview_card.dart';
 
-class MasonryFiles extends StatelessWidget {
+class MasonryFiles extends StatefulWidget {
   const MasonryFiles({
     super.key,
     required this.files,
     required this.crossAxisCount,
+    required this.setSelectedFiles,
   });
+
+  @override
+  State<MasonryFiles> createState() => _MasonryFilesState();
 
   final List<String> files;
   final int crossAxisCount;
 
   /// The number of files to display before showing an ad.
-  static const int itemsBeforeAd = 5;
+  final int itemsBeforeAd = 5;
+  
+  final void Function(List<String>) setSelectedFiles;
+
+}
+
+class _MasonryFilesState extends State<MasonryFiles> {
+  List<String> selectedFiles = [];
+
+  void toggleSelection(String filepath, bool selected) {
+    if(selected) {
+      selectedFiles.add(filepath);
+    } else {
+      selectedFiles.remove(filepath);
+    }
+    widget.setSelectedFiles(selectedFiles);
+  }
 
   @override
   Widget build(BuildContext context) {
     /// List of file paths with ads inserted every [itemsBeforeAd] items
     /// (ads are represented by null).
-    final List<String?> files = List.from(this.files);
+    final List<String?> files = List.from(widget.files);
     if (AdState.adsEnabled) {
       int numAds = 0;
-      for (int i = itemsBeforeAd; i < files.length; i += itemsBeforeAd) {
+      for (int i = widget.itemsBeforeAd; i < files.length; i += widget.itemsBeforeAd) {
         files.insert(i, null);
         numAds++;
       }
@@ -37,7 +57,7 @@ class MasonryFiles extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       sliver: SliverMasonryGrid.count(
         childCount: files.length,
-        crossAxisCount: crossAxisCount,
+        crossAxisCount: widget.crossAxisCount,
         mainAxisSpacing: 8,
         crossAxisSpacing: 8,
         itemBuilder: (context, index) {
@@ -56,6 +76,8 @@ class MasonryFiles extends StatelessWidget {
           } else {
             return PreviewCard(
               filePath: file,
+              toggleSelection: toggleSelection,
+              selected: selectedFiles.contains(file),
             );
           }
         },

--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -26,6 +26,7 @@ class MasonryFiles extends StatefulWidget {
 
 class _MasonryFilesState extends State<MasonryFiles> {
   List<String> selectedFiles = [];
+  ValueNotifier<bool> isAnythingSelected = ValueNotifier(false);
 
   void toggleSelection(String filepath, bool selected) {
     if(selected) {
@@ -33,6 +34,7 @@ class _MasonryFilesState extends State<MasonryFiles> {
     } else {
       selectedFiles.remove(filepath);
     }
+    isAnythingSelected.value = selectedFiles.isNotEmpty;
     widget.setSelectedFiles(selectedFiles);
   }
 
@@ -74,10 +76,16 @@ class _MasonryFilesState extends State<MasonryFiles> {
               ),
             );
           } else {
-            return PreviewCard(
-              filePath: file,
-              toggleSelection: toggleSelection,
-              selected: selectedFiles.contains(file),
+            return ValueListenableBuilder(
+              valueListenable: isAnythingSelected,
+              builder: (context, isAnythingSelected, _) {
+                return PreviewCard(
+                  filePath: file,
+                  toggleSelection: toggleSelection,
+                  selected: selectedFiles.contains(file),
+                  isAnythingSelected: isAnythingSelected,
+                );
+              }
             );
           }
         },

--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -16,15 +16,13 @@ class MasonryFiles extends StatefulWidget {
 
   final List<String> files;
   final int crossAxisCount;
-
-  /// The number of files to display before showing an ad.
-  final int itemsBeforeAd = 5;
-  
   final void Function(List<String>) setSelectedFiles;
-
 }
 
 class _MasonryFilesState extends State<MasonryFiles> {
+  /// The number of files to display before showing an ad.
+  static const int itemsBeforeAd = 5;
+
   List<String> selectedFiles = [];
   ValueNotifier<bool> isAnythingSelected = ValueNotifier(false);
 
@@ -45,7 +43,7 @@ class _MasonryFilesState extends State<MasonryFiles> {
     final List<String?> files = List.from(widget.files);
     if (AdState.adsEnabled) {
       int numAds = 0;
-      for (int i = widget.itemsBeforeAd; i < files.length; i += widget.itemsBeforeAd) {
+      for (int i = itemsBeforeAd; i < files.length; i += itemsBeforeAd) {
         files.insert(i, null);
         numAds++;
       }

--- a/lib/components/home/masonry_files.dart
+++ b/lib/components/home/masonry_files.dart
@@ -11,23 +11,23 @@ class MasonryFiles extends StatefulWidget {
     required this.setSelectedFiles,
   });
 
-  @override
-  State<MasonryFiles> createState() => _MasonryFilesState();
-
   final List<String> files;
   final int crossAxisCount;
   final void Function(List<String>) setSelectedFiles;
+
+  @override
+  State<MasonryFiles> createState() => _MasonryFilesState();
 }
 
 class _MasonryFilesState extends State<MasonryFiles> {
   /// The number of files to display before showing an ad.
   static const int itemsBeforeAd = 5;
 
-  List<String> selectedFiles = [];
-  ValueNotifier<bool> isAnythingSelected = ValueNotifier(false);
+  final List<String> selectedFiles = [];
+  final ValueNotifier<bool> isAnythingSelected = ValueNotifier(false);
 
   void toggleSelection(String filepath, bool selected) {
-    if(selected) {
+    if (selected) {
       selectedFiles.add(filepath);
     } else {
       selectedFiles.remove(filepath);

--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -138,7 +138,7 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
       parentFolderCounts[parentFolder] = (parentFolderCounts[parentFolder] ?? 0) + 1;
     }
     return parentFolderCounts.entries
-        .reduce((a, b) => a.value > b.value ? a : b)
+        .reduce((a, b) => a.value >= b.value ? a : b)
         .key;
   }
 

--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -108,7 +108,7 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
 
       newFileNames.add(newFileName);
 
-      if(newFileName != originalFileNames[i]) {
+      if (newFileName != originalFileNames[i]) {
         changedFileNames.add(newFileName);
       }
     }

--- a/lib/components/home/move_note_button.dart
+++ b/lib/components/home/move_note_button.dart
@@ -48,10 +48,10 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
   /// The original file names of the notes.
   late List<String> fileNames = widget.filesToMove.map((path) => path.substring(path.lastIndexOf('/') + 1)).toList();
 
-  /// The original parent folder of the notes,
+  /// The original parent folders of the notes,
   /// including the trailing slash.
   
-  late String parentFolder = widget.filesToMove[0].substring(0, widget.filesToMove[0].lastIndexOf('/') + 1);
+  late List<String> parentFolders = widget.filesToMove.map((path) => path.substring(0, path.lastIndexOf('/') + 1)).toList();
 
   late String _currentFolder;
   /// The current folder browsed to in the dialog.
@@ -69,13 +69,15 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
   /// with the same name already exists in the
   /// destination folder. In that case, the file name
   /// will be suffixed with a number.
-  List<String>? newFileNames;
+  List<String> newFileNames = [];
 
 
   Future findChildrenOfCurrentFolder() async {
     currentFolderChildren = await FileManager.getChildrenOfDirectory(currentFolder);
-    newFileNames = await Future.wait(widget.filesToMove.map((fileName) async => await FileManager.suffixFilePathToMakeItUnique('$currentFolder$fileName', false, '$parentFolder$fileName${Editor.extension}')
-      .then((newPath) => newPath.substring(newPath.lastIndexOf('/') + 1))).toList());
+    for(var i = 0; i < widget.filesToMove.length; i++){
+      newFileNames.add(await FileManager.suffixFilePathToMakeItUnique('$currentFolder${widget.filesToMove[i]}', false, '${parentFolders[i]}${widget.filesToMove[i]}${Editor.extension}')
+      .then((newPath) => newPath.substring(newPath.lastIndexOf('/') + 1)));
+    }
     if (!mounted) return;
     setState(() {});
   }
@@ -88,7 +90,7 @@ class _MoveNoteDialogState extends State<_MoveNoteDialog> {
 
   @override
   void initState() {
-    currentFolder = parentFolder;
+    currentFolder = parentFolders[0];
     super.initState();
   }
 

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -24,10 +24,12 @@ class PreviewCard extends StatefulWidget {
     required this.filePath,
     required this.toggleSelection,
     required this.selected,
+    required this.isAnythingSelected,
   }) : super(key: ValueKey('PreviewCard$filePath'));
 
   final String filePath;
   final bool selected;
+  final bool isAnythingSelected;
 
   @override
   State<PreviewCard> createState() => _PreviewCardState();
@@ -201,6 +203,7 @@ class _PreviewCardState extends State<PreviewCard> {
     Widget card = MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
+        onTap: widget.isAnythingSelected ? () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)} : null,
         onSecondaryTap: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
         onLongPress: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
         child: ColoredBox(

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -30,6 +30,7 @@ class PreviewCard extends StatefulWidget {
   final String filePath;
   final bool selected;
   final bool isAnythingSelected;
+  final void Function(String, bool) toggleSelection;
 
   @override
   State<PreviewCard> createState() => _PreviewCardState();
@@ -38,8 +39,6 @@ class PreviewCard extends StatefulWidget {
       => _PreviewCardState.getCachedCoreInfo(filePath);
   static void moveFileInCache(String oldPath, String newPath)
       => _PreviewCardState.moveFileInCache(oldPath, newPath);
-  
-  final void Function(String, bool) toggleSelection;
 }
 
 class _PreviewCardState extends State<PreviewCard> {
@@ -186,6 +185,11 @@ class _PreviewCardState extends State<PreviewCard> {
     if (mounted) setState(() {});
   }
 
+  void _toggleCardSelection() {
+    expanded.value = !expanded.value;
+    widget.toggleSelection(widget.filePath, expanded.value);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -203,9 +207,11 @@ class _PreviewCardState extends State<PreviewCard> {
     Widget card = MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
-        onTap: widget.isAnythingSelected ? () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)} : null,
-        onSecondaryTap: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
-        onLongPress: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
+        onTap: widget.isAnythingSelected
+          ? _toggleCardSelection
+          : null,
+        onSecondaryTap: _toggleCardSelection,
+        onLongPress: _toggleCardSelection,
         child: ColoredBox(
           color: colorScheme.primary.withOpacity(0.05),
           child: Stack(
@@ -250,7 +256,7 @@ class _PreviewCardState extends State<PreviewCard> {
                             ),
                           ),
                           child: GestureDetector(
-                            onTap: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
+                            onTap: _toggleCardSelection,
                             child: DecoratedBox(
                               decoration: BoxDecoration(
                                 gradient: LinearGradient(

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -8,8 +8,6 @@ import 'package:saber/components/canvas/_editor_image.dart';
 import 'package:saber/components/canvas/_stroke.dart';
 import 'package:saber/components/canvas/canvas_preview.dart';
 import 'package:saber/components/canvas/inner_canvas.dart';
-import 'package:saber/components/home/move_note_button.dart';
-import 'package:saber/components/home/rename_note_button.dart';
 import 'package:saber/components/home/uploading_indicator.dart';
 import 'package:saber/components/navbar/responsive_navbar.dart';
 import 'package:saber/data/editor/editor_core_info.dart';
@@ -24,9 +22,12 @@ import 'package:saber/pages/editor/editor.dart';
 class PreviewCard extends StatefulWidget {
   PreviewCard({
     required this.filePath,
+    required this.toggleSelection,
+    required this.selected,
   }) : super(key: ValueKey('PreviewCard$filePath'));
 
   final String filePath;
+  final bool selected;
 
   @override
   State<PreviewCard> createState() => _PreviewCardState();
@@ -35,6 +36,8 @@ class PreviewCard extends StatefulWidget {
       => _PreviewCardState.getCachedCoreInfo(filePath);
   static void moveFileInCache(String oldPath, String newPath)
       => _PreviewCardState.moveFileInCache(oldPath, newPath);
+  
+  final void Function(String, bool) toggleSelection;
 }
 
 class _PreviewCardState extends State<PreviewCard> {
@@ -137,6 +140,7 @@ class _PreviewCardState extends State<PreviewCard> {
     }
     fileWriteSubscription = FileManager.fileWriteStream.stream.listen(fileWriteListener);
 
+    expanded.value = widget.selected;
     super.initState();
   }
 
@@ -197,8 +201,8 @@ class _PreviewCardState extends State<PreviewCard> {
     Widget card = MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
-        onSecondaryTap: () => expanded.value = !expanded.value,
-        onLongPress: () => expanded.value = !expanded.value,
+        onSecondaryTap: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
+        onLongPress: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
         child: ColoredBox(
           color: colorScheme.primary.withOpacity(0.05),
           child: Stack(
@@ -243,7 +247,7 @@ class _PreviewCardState extends State<PreviewCard> {
                             ),
                           ),
                           child: GestureDetector(
-                            onTap: () => expanded.value = !expanded.value,
+                            onTap: () => {expanded.value = !expanded.value, widget.toggleSelection(widget.filePath, expanded.value)},
                             child: DecoratedBox(
                               decoration: BoxDecoration(
                                 gradient: LinearGradient(
@@ -258,26 +262,6 @@ class _PreviewCardState extends State<PreviewCard> {
                               ),
                               child: ColoredBox(
                                 color: colorScheme.primary.withOpacity(0.05),
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                  children: [
-                                    RenameNoteButton(
-                                      existingPath: widget.filePath,
-                                    ),
-                                    MoveNoteButton(
-                                      existingPath: widget.filePath,
-                                    ),
-                                    IconButton(
-                                      padding: EdgeInsets.zero,
-                                      tooltip: t.home.deleteNote,
-                                      onPressed: () {
-                                        FileManager.deleteFile(widget.filePath + Editor.extension);
-                                      },
-                                      icon: const Icon(Icons.delete_forever),
-                                    ),
-                                  ],
-                                ),
                               ),
                             ),
                           ),

--- a/lib/components/home/preview_card.dart
+++ b/lib/components/home/preview_card.dart
@@ -289,27 +289,33 @@ class _PreviewCardState extends State<PreviewCard> {
       ),
     );
 
-    return OpenContainer(
-      closedColor: colorScheme.surface,
-      closedShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      closedBuilder: (context, action) => card,
+    return ValueListenableBuilder(
+      valueListenable: expanded,
+      builder: (context, expanded, _) {
+        return OpenContainer(
+          closedColor: colorScheme.surface,
+          closedShape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          closedElevation: expanded ? 4 : 1,
+          closedBuilder: (context, action) => card,
 
-      openColor: colorScheme.background,
-      openBuilder: (context, action) => Editor(path: widget.filePath),
+          openColor: colorScheme.background,
+          openBuilder: (context, action) => Editor(path: widget.filePath),
 
-      transitionDuration: transitionDuration,
-      routeSettings: RouteSettings(
-        name: RoutePaths.editFilePath(widget.filePath),
-      ),
+          transitionDuration: transitionDuration,
+          routeSettings: RouteSettings(
+            name: RoutePaths.editFilePath(widget.filePath),
+          ),
 
-      onClosed: (_) async {
-        findStrokes();
+          onClosed: (_) async {
+            findStrokes();
 
-        await Future.delayed(transitionDuration);
-        if (!mounted) return;
-        if (!GoRouterState.of(context).uri.toString().startsWith(RoutePaths.prefixOfHome)) return;
-        ResponsiveNavbar.setAndroidNavBarColor(theme);
-      },
+            await Future.delayed(transitionDuration);
+            if (!mounted) return;
+            if (!GoRouterState.of(context).uri.toString().startsWith(RoutePaths.prefixOfHome)) return;
+            ResponsiveNavbar.setAndroidNavBarColor(theme);
+          },
+        );
+      }
     );
   }
 

--- a/lib/data/file_manager/file_manager.dart
+++ b/lib/data/file_manager/file_manager.dart
@@ -366,6 +366,9 @@ class FileManager {
   ///
   /// Providing a [currentPath] means that e.g. "/Untitled (2)" being renamed
   /// to "/Untitled" will be returned as "/Untitled (2)" not "/Untitled (3)".
+  /// 
+  /// If [currentPath] is provided, it must
+  /// end with [Editor.extension] or [Editor.extensionOldJson].
   static Future<String> suffixFilePathToMakeItUnique(String filePath, bool useOldExtension, [String? currentPath]) async {
     String newFilePath = filePath;
     bool hasExtension = false;

--- a/lib/i18n/_missing_translations.yaml
+++ b/lib/i18n/_missing_translations.yaml
@@ -11,7 +11,10 @@ ar:
     invalidFormat(OUTDATED): "The file you selected is not supported. Please select a .sbn, .sbn2 or .pdf file."
     backFolder(OUTDATED): Go back to the previous folder
     moveNote:
+      moveNotes: Move $n notes
       moveName(OUTDATED): Move $f
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
     deleteNote(OUTDATED): Delete note
     renameFolder:
       renameFolder(OUTDATED): Rename folder
@@ -57,6 +60,11 @@ ar:
       bgPatterns:
         tablature(OUTDATED): Tablature
 cs:
+  home:
+    moveNote:
+      moveNotes: Move $n notes
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
 de:
   home:
     titles:
@@ -66,6 +74,10 @@ de:
       importNote(OUTDATED): Import note
     invalidFormat(OUTDATED): "The file you selected is not supported. Please select a .sbn, .sbn2 or .pdf file."
     backFolder(OUTDATED): Go back to the previous folder
+    moveNote:
+      moveNotes: Move $n notes
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
     deleteNote(OUTDATED): Delete note
     renameFolder:
       renameFolder(OUTDATED): Rename folder
@@ -114,6 +126,10 @@ es:
 fa:
   home:
     invalidFormat(OUTDATED): "The file you selected is not supported. Please select a .sbn, .sbn2 or .pdf file."
+    moveNote:
+      moveNotes: Move $n notes
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
     renameFolder:
       renameFolder(OUTDATED): Rename folder
       folderName(OUTDATED): Folder name
@@ -175,9 +191,12 @@ hu:
       noteNameExists(OUTDATED): A note with this name already exists
     moveNote:
       moveNote(OUTDATED): Move note
+      moveNotes: Move $n notes
       moveName(OUTDATED): Move $f
       move(OUTDATED): Move
       renamedTo(OUTDATED): Note will be renamed to $newName
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
     deleteNote(OUTDATED): Delete note
     renameFolder:
       renameFolder(OUTDATED): Rename folder
@@ -310,6 +329,11 @@ hu:
       lockAxisAlignedPan(OUTDATED): Lock panning to horizontal or vertical
     needsToSaveBeforeExiting(OUTDATED): Saving your changes... You can safely exit the editor when it's done
 it:
+  home:
+    moveNote:
+      moveNotes: Move $n notes
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
 ja:
   home:
     titles:
@@ -319,6 +343,10 @@ ja:
       importNote(OUTDATED): Import note
     invalidFormat(OUTDATED): "The file you selected is not supported. Please select a .sbn, .sbn2 or .pdf file."
     backFolder(OUTDATED): Go back to the previous folder
+    moveNote:
+      moveNotes: Move $n notes
+      multipleRenamedTo: "The following notes will be renamed:"
+      numberRenamedTo: $n notes will be renamed
     deleteNote(OUTDATED): Delete note
     renameFolder:
       renameFolder(OUTDATED): Rename folder

--- a/lib/i18n/_unused_translations.yaml
+++ b/lib/i18n/_unused_translations.yaml
@@ -2,6 +2,9 @@
   - "Here are translations that exist in secondary locales but not in <en>."
   - "[--full enabled] Furthermore, translations not used in 'lib/' according to the 't.<path>' pattern are written into <en>."
 en:
+  home:
+    moveNote:
+      numberRenamedTo: $n notes will be renamed
 ar:
 cs:
 de:

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 3872 (242 per locale)
+/// Strings: 3875 (242 per locale)
 ///
-/// Built on 2023-10-21 at 21:16 UTC
+/// Built on 2023-10-21 at 22:25 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -397,7 +397,7 @@ class _StringsHomeMoveNoteEn {
 	String get move => 'Move';
 	String renamedTo({required Object newName}) => 'Note will be renamed to ${newName}';
 	String get multipleRenamedTo => 'The following notes will be renamed:';
-	String numberRenamedTo({required Object n}) => '${n} notes will be renamed';
+	String numberRenamedTo({required Object n}) => '${n} notes will be renamed to avoid conflicts';
 }
 
 // Path: home.renameFolder

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -392,9 +392,12 @@ class _StringsHomeMoveNoteEn {
 
 	// Translations
 	String get moveNote => 'Move note';
+	String moveNotes({required Object n}) => 'Move ${n} notes';
 	String moveName({required Object f}) => 'Move ${f}';
 	String get move => 'Move';
 	String renamedTo({required Object newName}) => 'Note will be renamed to ${newName}';
+	String get multipleRenamedTo => 'The following notes will be renamed:';
+	String numberRenamedTo({required Object n}) => '${n} notes will be renamed';
 }
 
 // Path: home.renameFolder

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -41,7 +41,7 @@ home:
     move: Move
     renamedTo: Note will be renamed to $newName
     multipleRenamedTo: "The following notes will be renamed:"
-    numberRenamedTo: "$n notes will be renamed"
+    numberRenamedTo: $n notes will be renamed to avoid conflicts
   deleteNote: Delete note
   renameFolder:
     renameFolder: Rename folder

--- a/lib/i18n/strings.i18n.yaml
+++ b/lib/i18n/strings.i18n.yaml
@@ -36,9 +36,12 @@ home:
     noteNameExists: A note with this name already exists
   moveNote:
     moveNote: Move note
+    moveNotes: Move $n notes
     moveName: Move $f
     move: Move
     renamedTo: Note will be renamed to $newName
+    multipleRenamedTo: "The following notes will be renamed:"
+    numberRenamedTo: "$n notes will be renamed"
   deleteNote: Delete note
   renameFolder:
     renameFolder: Rename folder

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -146,7 +146,7 @@ class _RecentPageState extends State<RecentPage> {
             builder: (context, selectedFiles, child) {
               return Collapsible(
                 axis: CollapsibleAxis.vertical,
-                collapsed: selectedFiles.length != 1,
+                collapsed: selectedFiles.isEmpty,
                 child: MoveNoteButton(filesToMove: selectedFiles),
               );
             },


### PR DESCRIPTION
This replaces the buttons that appear when you select a note by a bar on the bottom which these buttons on it. When multiple files are selected at once, it is now possible to move or delete them (exporting/sharing multiple notes at once, like suggested in #922 could be added to the bar as well). Renaming is only possible, when only one note is selected. Otherwise, the button is hidden. Also, this fixes a bug that caused the selection of a note to disappear when the note is not visible anymore after scrolling. 