### PR TITLE
i18n: Update German

### DIFF
--- a/lib/i18n/community/strings_de.i18n.yaml
+++ b/lib/i18n/community/strings_de.i18n.yaml
@@ -45,7 +45,7 @@ home:
     folderNameContainsSlash(OUTDATED): Der Ordnername darf keinen Schrägstrich enthalten
     folderNameExists(OUTDATED): Ein Ordner mit diesem Namen existiert bereits
   deleteFolder:
-    deleteName(OUTDATED): Löschen Sie $f
+    deleteName(OUTDATED): $f löschen
     deleteFolder(OUTDATED): Lösche Ordner
     delete(OUTDATED): Löschen
     alsoDeleteContents(OUTDATED): Lösche außerdem alle Notizen in diesem Ordner
@@ -297,4 +297,4 @@ editor:
     lockAxisAlignedPan: Verschieben auf Horizontale oder Vertikale beschränken
   pages: Seiten
   untitled: Unbenannt
-  needsToSaveBeforeExiting: "Deine Änderungen werden gespeichert... Du kannst den Editor ohne Datenverlust verlassen, wenn der Vorgang beendet ist."
+  needsToSaveBeforeExiting: "Deine Änderungen werden gespeichert... Du kannst den Editor ohne Datenverlust verlassen, sobald der Vorgang beendet ist."

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 15
 /// Strings: 3630 (242 per locale)
 ///
-/// Built on 2023-10-20 at 09:05 UTC
+/// Built on 2023-10-20 at 09:07 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2639,7 +2639,7 @@ class _StringsEditorDe extends _StringsEditorEn {
 	@override late final _StringsEditorHudDe hud = _StringsEditorHudDe._(_root);
 	@override String get pages => 'Seiten';
 	@override String get untitled => 'Unbenannt';
-	@override String get needsToSaveBeforeExiting => 'Deine Änderungen werden gespeichert... Du kannst den Editor ohne Datenverlust verlassen, wenn der Vorgang beendet ist.';
+	@override String get needsToSaveBeforeExiting => 'Deine Änderungen werden gespeichert... Du kannst den Editor ohne Datenverlust verlassen, sobald der Vorgang beendet ist.';
 }
 
 // Path: home.tabs
@@ -2755,7 +2755,7 @@ class _StringsHomeDeleteFolderDe extends _StringsHomeDeleteFolderEn {
 	@override final _StringsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String deleteName({required Object f}) => 'Löschen Sie ${f}';
+	@override String deleteName({required Object f}) => '${f} löschen';
 	@override String get deleteFolder => 'Lösche Ordner';
 	@override String get delete => 'Löschen';
 	@override String get alsoDeleteContents => 'Lösche außerdem alle Notizen in diesem Ordner';


### PR DESCRIPTION
Minor changes (two words) to be more precise and consistent with the rest of the translation.

„Löschen Sie $f“ uses the obsolete formal you, „$f löschen“ is more precise and in "tune" with the rest of the strings.

The change from "wenn" to "sobald" is more subtle: "wenn", in this context, works like an "if", but it is not an if-case and rather an "as soon as"-case aka. "sobald".