### PR TITLE
fix: update multi-selection buttons after changing selection

### DIFF
--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -178,7 +178,7 @@ class _BrowsePageState extends State<BrowsePage> {
                     for (String filePath in children?.files ?? const [])
                       "${path ?? ""}/$filePath",
                   ],
-                  setSelectedFiles: (files) => selectedFiles.value = files,
+                  setSelectedFiles: (files) => selectedFiles.value = List.from(files),
                 ),
               ),
             ],

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -118,7 +118,7 @@ class _RecentPageState extends State<RecentPage> {
                   files: [
                     for (String filePath in filePaths) filePath,
                   ],
-                  setSelectedFiles: (files) => selectedFiles.value = files,
+                  setSelectedFiles: (files) => selectedFiles.value = List.from(files),
                 ),
               ),
             ],


### PR DESCRIPTION
Currently, the button to rename a note is not hidden when multiple notes are selected. This is because selectedFiles just contains a reference to the values stored in the list, which doesn't change when you change the content of the list (except for when it's empty and you add something or when you remove everything from the list), so the ValueListenables are not called. By creating a new list every time the selection changes, the reference changes and therefore the rename button is hidden when selecting two notes or more. You can also call selectedFiles.notifyListeners(), but that causes some warnings.