### PR TITLE
feat: confirmation prompt for deleting selected notes

### DIFF
--- a/lib/components/home/delete_note_button.dart
+++ b/lib/components/home/delete_note_button.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:saber/components/theming/adaptive_alert_dialog.dart';
+import 'package:saber/data/file_manager/file_manager.dart';
+import 'package:saber/i18n/strings.g.dart';
+import 'package:saber/pages/editor/editor.dart';
+
+class DeleteNoteButton extends StatelessWidget {
+  const DeleteNoteButton({
+    super.key,
+    required this.filesToDelete,
+    required this.unselectNotes,
+  });
+
+  final List<String> filesToDelete;
+  final void Function() unselectNotes;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: EdgeInsets.zero,
+      tooltip: t.home.deleteNote,
+      onPressed: () async {
+        await showDialog(
+          context: context,
+          builder: (context) => _DeleteNoteDialog(
+            filesToDelete: filesToDelete,
+            unselectNotes: unselectNotes,
+          ),
+        );
+      },
+      icon: const Icon(Icons.delete_forever),
+    );
+  }
+}
+
+class _DeleteNoteDialog extends StatefulWidget {
+  const _DeleteNoteDialog({
+    required this.filesToDelete,
+    required this.unselectNotes,
+  });
+
+  final List<String> filesToDelete;
+  final void Function() unselectNotes;
+
+  @override
+  State<_DeleteNoteDialog> createState() => _DeleteNoteDialogState();
+}
+
+class _DeleteNoteDialogState extends State<_DeleteNoteDialog> {
+  var deleteAllowed = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveAlertDialog(
+      title: widget.filesToDelete.length < 5
+          ? Text(
+              t.home.deleteNoteDialog.deleteName(
+                f: widget.filesToDelete.join(', '),
+              ),
+            )
+          : Text(
+              t.home.deleteNoteDialog.deleteNotes(
+                n: widget.filesToDelete.length,
+              ),
+            ),
+      content: Row(
+        children: [
+          Checkbox(
+            value: deleteAllowed,
+            onChanged: (value) => setState(() => deleteAllowed = value!),
+          ),
+          Expanded(child: Text(t.home.deleteNoteDialog.deleteAllowed)),
+        ],
+      ),
+      actions: [
+        CupertinoDialogAction(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(t.common.cancel),
+        ),
+        CupertinoDialogAction(
+          onPressed: deleteAllowed
+              ? () async {
+                  await Future.wait([
+                    for (final String filePath in widget.filesToDelete)
+                      Future.value(
+                        FileManager.doesFileExist(
+                          filePath + Editor.extensionOldJson,
+                        ),
+                      ).then(
+                        (oldExtension) => FileManager.deleteFile(
+                          filePath +
+                              (oldExtension
+                                  ? Editor.extensionOldJson
+                                  : Editor.extension),
+                        ),
+                      ),
+                  ]);
+                  if (context.mounted) Navigator.of(context).pop();
+                  widget.unselectNotes();
+                }
+              : null,
+          isDestructiveAction: true,
+          child: Text(t.home.deleteNoteDialog.delete),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/components/home/delete_note_button.dart
+++ b/lib/components/home/delete_note_button.dart
@@ -69,14 +69,11 @@ class _DeleteNoteDialogState extends State<_DeleteNoteDialog> {
                 n: widget.filesToDelete.length,
               ),
             ),
-      content: Row(
-        children: [
-          Checkbox(
-            value: deleteAllowed,
-            onChanged: (value) => setState(() => deleteAllowed = value!),
-          ),
-          Expanded(child: Text(t.home.deleteNoteDialog.confirmDelete)),
-        ],
+      content: CheckboxListTile.adaptive(
+        value: deleteAllowed,
+        onChanged: (value) => setState(() => deleteAllowed = value!),
+        controlAffinity: .leading,
+        title: Text(t.home.deleteNoteDialog.confirmDelete),
       ),
       actions: [
         CupertinoDialogAction(

--- a/lib/components/home/delete_note_button.dart
+++ b/lib/components/home/delete_note_button.dart
@@ -75,7 +75,7 @@ class _DeleteNoteDialogState extends State<_DeleteNoteDialog> {
             value: deleteAllowed,
             onChanged: (value) => setState(() => deleteAllowed = value!),
           ),
-          Expanded(child: Text(t.home.deleteNoteDialog.deleteAllowed)),
+          Expanded(child: Text(t.home.deleteNoteDialog.confirmDelete)),
         ],
       ),
       actions: [

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -50,6 +50,11 @@ home:
     multipleRenamedTo: "The following notes will be renamed:"
     numberRenamedTo: $n notes will be renamed to avoid conflicts
   deleteNote: Delete note
+  deleteNoteDialog:
+    deleteNotes: Delete $n notes
+    deleteName: Delete $f
+    deleteAllowed: Delete all selected notes (they cannot be restored)
+    delete: Delete
   renameFolder:
     renameFolder: Rename folder
     folderName: Folder name

--- a/lib/i18n/en.i18n.yaml
+++ b/lib/i18n/en.i18n.yaml
@@ -53,7 +53,7 @@ home:
   deleteNoteDialog:
     deleteNotes: Delete $n notes
     deleteName: Delete $f
-    deleteAllowed: Delete all selected notes (they cannot be restored)
+    confirmDelete: Permanently delete selected note(s)?
     delete: Delete
   renameFolder:
     renameFolder: Rename folder

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -496,8 +496,8 @@ class TranslationsHomeDeleteNoteDialogEn {
 	/// en: 'Delete $f'
 	String deleteName({required Object f}) => 'Delete ${f}';
 
-	/// en: 'Delete all selected notes (they cannot be restored)'
-	String get deleteAllowed => 'Delete all selected notes (they cannot be restored)';
+	/// en: 'Permanently delete selected note(s)?'
+	String get confirmDelete => 'Permanently delete selected note(s)?';
 
 	/// en: 'Delete'
 	String get delete => 'Delete';

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -102,6 +102,7 @@ class TranslationsHomeEn {
 	/// en: 'Delete note'
 	String get deleteNote => 'Delete note';
 
+	late final TranslationsHomeDeleteNoteDialogEn deleteNoteDialog = TranslationsHomeDeleteNoteDialogEn.internal(_root);
 	late final TranslationsHomeRenameFolderEn renameFolder = TranslationsHomeRenameFolderEn.internal(_root);
 	late final TranslationsHomeDeleteFolderEn deleteFolder = TranslationsHomeDeleteFolderEn.internal(_root);
 }
@@ -479,6 +480,27 @@ class TranslationsHomeMoveNoteEn {
 
 	/// en: '$n notes will be renamed to avoid conflicts'
 	String numberRenamedTo({required Object n}) => '${n} notes will be renamed to avoid conflicts';
+}
+
+// Path: home.deleteNoteDialog
+class TranslationsHomeDeleteNoteDialogEn {
+	TranslationsHomeDeleteNoteDialogEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Delete $n notes'
+	String deleteNotes({required Object n}) => 'Delete ${n} notes';
+
+	/// en: 'Delete $f'
+	String deleteName({required Object f}) => 'Delete ${f}';
+
+	/// en: 'Delete all selected notes (they cannot be restored)'
+	String get deleteAllowed => 'Delete all selected notes (they cannot be restored)';
+
+	/// en: 'Delete'
+	String get delete => 'Delete';
 }
 
 // Path: home.renameFolder

--- a/lib/pages/home/browse.dart
+++ b/lib/pages/home/browse.dart
@@ -4,6 +4,7 @@ import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path/path.dart' as p;
+import 'package:saber/components/home/delete_note_button.dart';
 import 'package:saber/components/home/export_note_button.dart';
 import 'package:saber/components/home/grid_folders.dart';
 import 'package:saber/components/home/masonry_files.dart';
@@ -17,7 +18,6 @@ import 'package:saber/components/theming/saber_theme.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';
-import 'package:saber/pages/editor/editor.dart';
 
 class BrowsePage extends StatefulWidget {
   const BrowsePage({super.key, String? path}) : initialPath = path;
@@ -227,28 +227,9 @@ class _BrowsePageState extends State<BrowsePage> {
                 filesToMove: selectedFiles.value,
                 unselectNotes: () => selectedFiles.value = [],
               ),
-              IconButton(
-                padding: .zero,
-                tooltip: t.home.deleteNote,
-                onPressed: () async {
-                  await Future.wait([
-                    for (final filePath in selectedFiles.value)
-                      Future.value(
-                        FileManager.doesFileExist(
-                          filePath + Editor.extensionOldJson,
-                        ),
-                      ).then(
-                        (oldExtension) => FileManager.deleteFile(
-                          filePath +
-                              (oldExtension
-                                  ? Editor.extensionOldJson
-                                  : Editor.extension),
-                        ),
-                      ),
-                  ]);
-                  selectedFiles.value = [];
-                },
-                icon: const Icon(Icons.delete_forever),
+              DeleteNoteButton(
+                filesToDelete: selectedFiles.value,
+                unselectNotes: () => selectedFiles.value = [],
               ),
               ExportNoteButton(selectedFiles: selectedFiles.value),
             ],

--- a/lib/pages/home/recent_notes.dart
+++ b/lib/pages/home/recent_notes.dart
@@ -4,6 +4,7 @@ import 'package:collapsible/collapsible.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
+import 'package:saber/components/home/delete_note_button.dart';
 import 'package:saber/components/home/export_note_button.dart';
 import 'package:saber/components/home/masonry_files.dart';
 import 'package:saber/components/home/move_note_button.dart';
@@ -16,7 +17,6 @@ import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/prefs.dart';
 import 'package:saber/data/routes.dart';
 import 'package:saber/i18n/strings.g.dart';
-import 'package:saber/pages/editor/editor.dart';
 
 class RecentPage extends StatefulWidget {
   const RecentPage({super.key});
@@ -180,28 +180,9 @@ class _RecentPageState extends State<RecentPage> {
                 filesToMove: selectedFiles.value,
                 unselectNotes: () => selectedFiles.value = [],
               ),
-              IconButton(
-                padding: .zero,
-                tooltip: t.home.deleteNote,
-                onPressed: () async {
-                  await Future.wait([
-                    for (final filePath in selectedFiles.value)
-                      Future.value(
-                        FileManager.doesFileExist(
-                          filePath + Editor.extensionOldJson,
-                        ),
-                      ).then(
-                        (oldExtension) => FileManager.deleteFile(
-                          filePath +
-                              (oldExtension
-                                  ? Editor.extensionOldJson
-                                  : Editor.extension),
-                        ),
-                      ),
-                  ]);
-                  selectedFiles.value = [];
-                },
-                icon: const Icon(Icons.delete_forever),
+              DeleteNoteButton(
+                filesToDelete: selectedFiles.value,
+                unselectNotes: () => selectedFiles.value = [],
               ),
               ExportNoteButton(selectedFiles: selectedFiles.value),
             ],


### PR DESCRIPTION
This adds a confirmation prompt for deleting selected notes, so you cannot accidentally delete notes by miss clicking if you want to export or move them. The prompt works exactly like the one for deleting folders.