### PR TITLE
fix: background patterns not triggering save

### DIFF
--- a/lib/data/editor/editor_history.dart
+++ b/lib/data/editor/editor_history.dart
@@ -213,4 +213,5 @@ enum EditorHistoryItemType {
   quillChange,
   quillUndoneChange,
   changeColor,
+  backgroundPattern,
 }

--- a/lib/pages/editor/editor.dart
+++ b/lib/pages/editor/editor.dart
@@ -438,6 +438,9 @@ class EditorState extends State<Editor> {
           for (final stroke in item.strokes) {
             stroke.color = item.colorChange![stroke]!.previous;
           }
+
+        case .backgroundPattern:
+          break;
       }
 
       if (item.type != .move) {
@@ -484,6 +487,8 @@ class EditorState extends State<Editor> {
             ),
           ),
         );
+      case .backgroundPattern:
+        break;
     }
   }
 
@@ -1757,6 +1762,14 @@ class EditorState extends State<Editor> {
         if (coreInfo.readOnly) return;
         coreInfo.backgroundPattern = pattern;
         stows.lastBackgroundPattern.value = pattern;
+        history.recordChange(
+          EditorHistoryItem(
+            type: EditorHistoryItemType.backgroundPattern,
+            pageIndex: currentPageIndex,
+            strokes: [],
+            images: [],
+          ),
+        );
         autosaveAfterDelay();
       }),
       setLineHeight: (lineHeight) => setState(() {


### PR DESCRIPTION
Fixes #1688

## Problem 

When you open a new note and change the background, the change is not saved when you exit the note. 

##  Fix 

To fix the issue, i added backgroundPattern to the EditorHistoryItemType enum in editor_history.dart and and modified to record these changes, so the background is now saved with the save button and autosave. It is now considered a  modification. 

## Tests performed 

Tested in Android Studio. Background changes are now considered a modification and are saved. 






 

