### PR TITLE
fix: Enable Custom Directories for the FOSS Android build only

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -236,6 +236,9 @@ jobs:
       - run: flutter pub get
       - run: ./patches/post/patch_rust_versions.sh
       - run: ./patches/post/remove_wasm_libs.sh
+      - name: Apply custom-dir changes to FOSS build
+        if: matrix.foss
+        run: ./patches/pre/enable_custom_dir_foss_android.sh
 
       - name: Build apk
         run: flutter build apk

--- a/lib/components/settings/custom_directory_selector_android.dart
+++ b/lib/components/settings/custom_directory_selector_android.dart
@@ -1,11 +1,9 @@
 /*
+  This file is for the Play Store build only
+
   This stub file gets replaced during the CI build process with:
-
   `custom_directory_selector_foss.dart`
-
-  for the FOSS build only.
-
-  Play Store build uses this noop stub
+  for the FOSS build.
 */
 import 'package:flutter/material.dart';
 

--- a/lib/components/settings/custom_directory_selector_android.dart
+++ b/lib/components/settings/custom_directory_selector_android.dart
@@ -1,0 +1,12 @@
+/*
+  This file gets replaced during the CI build process with:
+
+  `custom_directory_selector_foss.dart`
+
+  for the FOSS build only.
+
+  Play Store build uses this noop custom directory selector
+*/
+Future<void> onConfirmAndroid(BuildContext context, String directory) async {
+  return
+}

--- a/lib/components/settings/custom_directory_selector_android.dart
+++ b/lib/components/settings/custom_directory_selector_android.dart
@@ -1,11 +1,11 @@
 /*
-  This file gets replaced during the CI build process with:
+  This stub file gets replaced during the CI build process with:
 
   `custom_directory_selector_foss.dart`
 
   for the FOSS build only.
 
-  Play Store build uses this noop stub custom directory selector
+  Play Store build uses this noop stub
 */
 import 'package:flutter/material.dart';
 

--- a/lib/components/settings/custom_directory_selector_android.dart
+++ b/lib/components/settings/custom_directory_selector_android.dart
@@ -5,8 +5,12 @@
 
   for the FOSS build only.
 
-  Play Store build uses this noop custom directory selector
+  Play Store build uses this noop stub custom directory selector
 */
+import 'package:flutter/material.dart';
+
+bool isCustomDirSupported() => false;
+
 Future<void> onConfirmAndroid(BuildContext context, String directory) async {
-  return
+  return;
 }

--- a/lib/components/settings/custom_directory_selector_foss.dart
+++ b/lib/components/settings/custom_directory_selector_foss.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:saber/components/theming/adaptive_alert_dialog.dart';
 import 'package:saber/i18n/strings.g.dart';
+
+bool isCustomDirSupported() => true;
 
 Future<void> requestStoragePermission() async {
   final status = await Permission.manageExternalStorage.request();

--- a/lib/components/settings/custom_directory_selector_foss.dart
+++ b/lib/components/settings/custom_directory_selector_foss.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/cupertino.dart';
+import 'package:go_router/go_router.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:saber/components/theming/adaptive_alert_dialog.dart';
+import 'package:saber/i18n/strings.g.dart';
+
+Future<void> requestStoragePermission() async {
+  final status = await Permission.manageExternalStorage.request();
+  if (status.isDenied || status.isPermanentlyDenied) {
+    openAppSettings();
+  }
+}
+
+Future<void> onConfirmAndroid(BuildContext context, String directory) async {
+  if (directory.startsWith('/data/user/')) return;
+  if (await Permission.manageExternalStorage.isGranted) return;
+  if (!context.mounted) return;
+
+  showDialog(
+    context: context,
+    builder: (context) => AdaptiveAlertDialog(
+      title: Text(t.settings.customDataDir.grantPermission),
+      content: Text(t.settings.customDataDir.grantPermissionExplanation),
+      actions: [
+        CupertinoDialogAction(
+          onPressed: () => context.pop(),
+          child: Text(t.settings.customDataDir.cancel),
+        ),
+        CupertinoDialogAction(
+          isDefaultAction: true,
+          onPressed: () {
+            context.pop();
+            requestStoragePermission();
+          },
+          child: Text(t.settings.customDataDir.yes),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/components/settings/custom_directory_selector_foss.dart
+++ b/lib/components/settings/custom_directory_selector_foss.dart
@@ -1,3 +1,16 @@
+/*
+  This file is for the FOSS Android build only:
+
+  the stub `custom_directory_selector_android.dart`
+
+  is replaced with this file via the `enable_custom_dir_foss_android.sh` script
+
+  credit for the implementation for the permission selector code goes to @ComputerElite
+
+  original source PR: https://github.com/saber-notes/saber/pull/1448
+
+*/
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/components/settings/custom_directory_selector_foss.dart
+++ b/lib/components/settings/custom_directory_selector_foss.dart
@@ -2,11 +2,9 @@
   This file is for the FOSS Android build only:
 
   the stub `custom_directory_selector_android.dart`
-
   is replaced with this file via the `enable_custom_dir_foss_android.sh` script
 
   credit for the implementation for the permission selector code goes to @ComputerElite
-
   original source PR: https://github.com/saber-notes/saber/pull/1448
 
 */

--- a/lib/components/settings/settings_directory_selector.dart
+++ b/lib/components/settings/settings_directory_selector.dart
@@ -147,10 +147,11 @@ class _DirectorySelectorState extends State<DirectorySelector> {
       content: Column(
         mainAxisSize: .min,
         children: [
-          Text(
-            t.settings.customDataDir.unsupported,
-            style: TextStyle(color: colorScheme.error),
-          ),
+          if (!isCustomDirSupported())
+            Text(
+              t.settings.customDataDir.unsupported,
+              style: TextStyle(color: colorScheme.error),
+            ),
           Row(
             children: [
               Expanded(

--- a/lib/components/settings/settings_directory_selector.dart
+++ b/lib/components/settings/settings_directory_selector.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:saber/components/settings/custom_directory_selector_android.dart';
 import 'package:saber/components/theming/adaptive_alert_dialog.dart';
 import 'package:saber/data/file_manager/file_manager.dart';
 import 'package:saber/data/nextcloud/saber_syncer.dart';
@@ -123,9 +124,12 @@ class _DirectorySelectorState extends State<DirectorySelector> {
     setState(() {});
   }
 
-  void _onConfirm() {
+  void _onConfirm() async {
     stows.customDataDir.value = _directory;
     context.pop();
+    if (Platform.isAndroid) {
+      await onConfirmAndroid(context, _directory);
+    }
   }
 
   @override

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -818,6 +818,16 @@ class TranslationsSettingsCustomDataDirEn {
 	/// en: 'Select'
 	String get select => 'Select';
 
+	/// en: 'Yes'
+	String get yes => 'Yes';
+
+	/// en: 'Grant permission'
+	String get grantPermission => "Grant permission";
+
+	/// en: 'Saber needs permission to access the directory you chose. Do you want to grant this permission?'
+	String get grantPermissionExplanation =>
+      "Saber needs permission to access the directory you chose. Do you want to grant this permission?";
+
 	/// en: 'Selected folder must be empty'
 	String get mustBeEmpty => 'Selected folder must be empty';
 

--- a/patches/pre/enable_custom_dir_foss_android.sh
+++ b/patches/pre/enable_custom_dir_foss_android.sh
@@ -2,6 +2,8 @@
 #
 # Enables custom directories for the Android FOSS build
 
+# Update Manifest
+
 MANIFEST="android/app/src/main/AndroidManifest.xml"
 
 echo -n "Adding MANAGE_EXTERNAL_STORAGE permission to AndroidManifest.xml: "
@@ -12,3 +14,15 @@ else
   sed -i 's|<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />|<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />\n    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />|' "$MANIFEST"
 fi
 
+# replace stub with FOSS version of custom directory selector
+
+ANDROID_DART="lib/components/settings/custom_directory_selector_android.dart"
+FOSS_DART="lib/components/settings/custom_directory_selector_foss.dart"
+
+echo -n "Replacing custom_directory_selector_android.dart with FOSS version: "
+if diff -q "$ANDROID_DART" "$FOSS_DART" > /dev/null 2>&1; then
+  echo "already done"
+else
+  echo "replacing"
+  mv "$FOSS_DART" "$ANDROID_DART"
+fi

--- a/patches/pre/enable_custom_dir_foss_android.sh
+++ b/patches/pre/enable_custom_dir_foss_android.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Enables custom directories for the Android FOSS build
+
+MANIFEST="android/app/src/main/AndroidManifest.xml"
+
+echo -n "Adding MANAGE_EXTERNAL_STORAGE permission to AndroidManifest.xml: "
+if grep -q "MANAGE_EXTERNAL_STORAGE" "$MANIFEST"; then
+  echo "already done"
+else
+  echo "adding"
+  sed -i 's|<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />|<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />\n    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />|' "$MANIFEST"
+fi
+

--- a/patches/pre/enable_custom_dir_foss_android.sh
+++ b/patches/pre/enable_custom_dir_foss_android.sh
@@ -24,5 +24,5 @@ if diff -q "$ANDROID_DART" "$FOSS_DART" > /dev/null 2>&1; then
   echo "already done"
 else
   echo "replacing"
-  mv "$FOSS_DART" "$ANDROID_DART"
+  cp "$FOSS_DART" "$ANDROID_DART"
 fi

--- a/test/custom_directory_selector_android_test.dart
+++ b/test/custom_directory_selector_android_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saber/components/settings/custom_directory_selector_android.dart';
+
+void main() {
+  group('custom_directory_selector_android (Play Store stub)', () {
+    test('isCustomDirSupported returns false', () {
+      expect(isCustomDirSupported(), false);
+    });
+
+    testWidgets('onConfirmAndroid is a no-op and shows no dialog', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+      final context = tester.element(find.byType(SizedBox));
+
+      await onConfirmAndroid(context, '/storage/emulated/0/Saber');
+
+      await tester.pump();
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+}

--- a/test/custom_directory_selector_foss_test.dart
+++ b/test/custom_directory_selector_foss_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saber/components/settings/custom_directory_selector_foss.dart';
+
+void main() {
+  group('custom_directory_selector_foss (FOSS build)', () {
+    test('isCustomDirSupported returns true', () {
+      expect(isCustomDirSupported(), true);
+    });
+
+    testWidgets(
+      'onConfirmAndroid returns early for /data/user/ paths and shows no dialog',
+      (tester) async {
+        await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+        final context = tester.element(find.byType(SizedBox));
+
+        // Paths under /data/user/ are internal app storage; no permission needed.
+        await onConfirmAndroid(context, '/data/user/0/com.example.saber/files');
+
+        await tester.pump();
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
# Summary 

This PR adds support for Custom Directories for the **FOSS Android build only**

This PR is heavily based on the work done by @ComputerElite in PR #1448 

Note that I'm not an Android developer by trade, I'm primarily a web developer. Please let me know if I overlooked something, or if there's any other problems.

# Implementation details

- Create android-specific Custom Directory Selector
  - create a stub version for the Play store build
  - create a separate FOSS version that implements the external directory prompt
- add a pre script that enables the custom dir for the FOSS build
- update github pipeline to add the required changes for the FOSS build

# Tests performed

Debug builds tested on the following devices:

- S21 Ultra (Android 15)
- Galaxy Fold 3 (Android 15)

Custom dir worked as expected for the FOSS build, also the non-FOSS build behaved as-expected.

## Partially fixes:
Issue #1223 